### PR TITLE
Winkelgebieden: translation of generated PK col name to 'ID'

### DIFF
--- a/src/dags/winkelgebieden.py
+++ b/src/dags/winkelgebieden.py
@@ -50,7 +50,9 @@ with DAG(
         task_id="extract_data",
         bash_command=f"ogr2ogr -f 'PGDump' "
         f"-t_srs EPSG:28992 -nln {dag_id}_new "
-        f"{tmp_dir}/{dag_id}.sql {data_path}/{dag_id}/winkgeb2018.TAB",
+        f"{tmp_dir}/{dag_id}.sql {data_path}/{dag_id}/winkgeb2018.TAB "
+        # the option -lco is added to rename the automated creation of the primairy key column (ogc fid) - due to use of ogr2ogr - to id so its conform the Amsterdam schema standard and passes the validation
+        f"-lco FID=ID",
     )
 
     convert_data = BashOperator(
@@ -102,3 +104,18 @@ with DAG(
     >> [check_count, check_geo]
     >> rename_table
 )
+
+dag.doc_md = '''
+    #### DAG summery
+    This DAG containts permit announcements (bekendmakingen)
+    #### Mission Critical
+    Classified as 2 (beschikbaarheid [range: 1,2,3])
+    #### On Failure Actions
+    Fix issues and rerun dag on working days
+    #### Point of Contact
+    Inform the businessowner at [businessowner]@amsterdam.nl
+    #### Business Use Case / process
+    Permit allowance (vergunningverlening)
+    #### Prerequisites/Dependencies/Resourcing
+    None
+'''


### PR DESCRIPTION
To meet the prerequisite of the Amsterdams Schema of having an 'ID' attribute, the creation of the winkgeb table is adjusted so the generated PK column 'ogc fid' is translated to 'id'
The translation is realized by adding the -lco (Layer creation option) option to the ogr2ogr command. The -lco takes an attribute identifier as input and its transalation. I.e. FID=ID.