### PR TITLE
Fix error on reading sql template files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       POSTGRES_DB: ds_airflow
       POSTGRES_USER: ds_airflow
       POSTGRES_PASSWORD: insecure
-      AIRFLOW_CONN_POSTGRES_DEFAULT: |
-        postgresql://ds_airflow:insecure@database:5432/ds_airflow?cursor=dictcursor&
+      AIRFLOW_CONN_POSTGRES_DEFAULT: "postgresql://ds_airflow:insecure@database:5432\
+        /ds_airflow?cursor=dictcursor&"
       FERNET_KEY: ${FERNET_KEY}
       AIRFLOW__WEBSERVER__BASE_URL: http://localhost:8080/
       DATAPUNT_ENVIRONMENT: development

--- a/src/dags/fietspaaltjes.py
+++ b/src/dags/fietspaaltjes.py
@@ -3,6 +3,7 @@ from airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from http_fetch_operator import HttpFetchOperator
+from postgres_files_operator import PostgresFilesOperator
 
 from common import (
     default_args,
@@ -43,9 +44,9 @@ with DAG(dag_id, default_args=default_args, template_searchpath=["/"]) as dag:
         op_args=[f"{tmp_dir}/{dag_id}.json", f"{tmp_dir}/{dag_id}.sql",],
     )
 
-    create_and_fill_table = PostgresOperator(
+    create_and_fill_table = PostgresFilesOperator(
         task_id="create_and_fill_table",
-        sql=[f"{sql_path}/fietspaaltjes_create.sql", f"{tmp_dir}/{dag_id}.sql"],
+        sql_files=[f"{sql_path}/fietspaaltjes_create.sql", f"{tmp_dir}/{dag_id}.sql"],
     )
 
     rename_table = PostgresOperator(

--- a/src/dags/iot.py
+++ b/src/dags/iot.py
@@ -9,6 +9,7 @@ from airflow.models import Variable
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from http_fetch_operator import HttpFetchOperator
+from postgres_files_operator import PostgresFilesOperator
 
 from common import (
     default_args,
@@ -113,13 +114,16 @@ with DAG(dag_id, default_args=default_args, template_searchpath=["/"]) as dag:
         ],
     )
 
-    create_tables = PostgresOperator(
-        task_id="create_tables", sql=f"{sql_path}/iot_data_create.sql",
+    create_tables = PostgresFilesOperator(
+        task_id="create_tables", sql_files=[f"{sql_path}/iot_data_create.sql"],
     )
 
-    import_data = PostgresOperator(
+    import_data = PostgresFilesOperator(
         task_id="import_data",
-        sql=[f"{tmp_dir}/iot_things_new.sql", f"{tmp_dir}/iot_locations_new.sql",],
+        sql_files=[
+            f"{tmp_dir}/iot_things_new.sql",
+            f"{tmp_dir}/iot_locations_new.sql",
+        ],
     )
 
     rename_tables = PostgresOperator(task_id="rename_tables", sql=SQL_TABLE_RENAMES)

--- a/src/plugins/postgres_files_operator.py
+++ b/src/plugins/postgres_files_operator.py
@@ -1,0 +1,16 @@
+from airflow.operators.bash_operator import BashOperator
+from airflow.hooks.base_hook import BaseHook
+
+
+pg_params = " ".join(["-1", "-X", "--set", "ON_ERROR_STOP",])
+
+
+class PostgresFilesOperator(BashOperator):
+    def __init__(self, sql_files, conn_id="postgres_default", *args, **kwargs):
+        """ Connection uri has a 'cursor' argument, psql does not recognize it
+            and it is not needed here, so we chop it off
+        """
+        connection_uri = BaseHook.get_connection(conn_id).get_uri().split("?")[0]
+        paths = " ".join(f'"{f}"' for f in sql_files)
+        bash_command = f'cat {paths} | psql "{connection_uri}" {pg_params}'
+        super().__init__(*args, bash_command=bash_command, **kwargs)


### PR DESCRIPTION
During dagbag the sql files in PostgresOperator are evaluated.
However, they are not existing at that moment, leading to lots of errors
that go undetected during development due to a missing logging handler.