### PR TITLE
Meetbouten

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       DAG_SYNC_PATH: /tmp/synced-dags
       OPENBARE_VERLICHTING_DATA_SRC: https://asd2.techtek.eu/asd/services/rest_sia.php/SIAService/objecten
       OPENBARE_VERLICHTING_DATA_TYPES_SRC: https://asd2.techtek.eu/asd/services/rest_sia.php/SIAService/types
+      SCHEMA_URL: ${SCHEMA_URL}
     volumes:
       - ./src/dags:/usr/local/airflow/dags
       - ./src/plugins:/usr/local/airflow/plugins

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER datapunt@amsterdam.nl
 # Seems that pg_comparator installs full postgresql, that's not what we want
 # RUN apt-get update && apt-get install -y postgresql-comparator
 RUN apt-get update \
- && apt-get install --no-install-recommends -y rsync libaio1
+ && apt-get install --no-install-recommends -y rsync libaio1 supervisor
 COPY requirements* ./
 ARG PIP_REQUIREMENTS=requirements.txt
 RUN pip install --no-cache-dir -r $PIP_REQUIREMENTS

--- a/src/config/supervisord.conf
+++ b/src/config/supervisord.conf
@@ -7,6 +7,10 @@ user = root
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
+; This *.sock file here has to match the serverurl in [supervisorclt]
+[unix_http_server]
+file=/tmp/supervisord.sock
+
 [supervisorctl]
 serverurl=unix:////tmp/supervisord.sock
 

--- a/src/dags/meetbouten.py
+++ b/src/dags/meetbouten.py
@@ -1,21 +1,86 @@
+import json
 from airflow import DAG
+from postgres_rename_operator import PostgresTableRenameOperator
 from http_gob_operator import HttpGobOperator
 from common import default_args
 
 
 graphql_query = """{"query":"{  meetboutenMeetbouten($active: false, publiceerbaar: true) {    edges {      node {        identificatie         nabijNummeraanduiding {          edges {            node {              identificatie               volgnummer             }          }        }        locatie         status         vervaldatum         merk         xCoordinaatMuurvlak         yCoordinaatMuurvlak         windrichting         ligtInBouwblok {          edges {            node {              identificatie               volgnummer             }          }        }        ligtInBuurt {          edges {            node {              identificatie               volgnummer             }          }        }        ligtInStadsdeel {          edges {            node {              identificatie               volgnummer             }          }        }        geometrie         publiceerbaar       }    }  }}"}"""
 
+
+gql = """{
+    meetboutenMeetbouten($active: false, publiceerbaar: true) {
+      edges {
+        node {
+          identificatie
+          nabijNummeraanduiding {
+            edges {
+              node {
+                identificatie
+                volgnummer
+              }
+            }
+          }
+          locatie
+          status
+          vervaldatum
+          merk
+          xCoordinaatMuurvlak
+          yCoordinaatMuurvlak
+          windrichting
+          ligtInBouwblok {
+            edges {
+              node {
+                identificatie
+                volgnummer
+              }
+            }
+          }
+          ligtInBuurt {
+            edges {
+              node {
+                identificatie
+                volgnummer
+              }
+            }
+          }
+          ligtInStadsdeel {
+            edges {
+              node {
+                identificatie
+                volgnummer
+              }
+            }
+          }
+          geometrie
+          publiceerbaar
+        }
+      }
+    }
+}
+"""
+graphql_query_new = {"query": f"{gql}"}
 dag_id = "meetbouten"
 owner = "gob"
 
+
 with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
 
-    http_load_task = HttpGobOperator(
-        task_id="http_load_task",
+    data_load_task = HttpGobOperator(
+        task_id="data_load_task",
         endpoint="gob/graphql/streaming/",
-        schema="meetbouten_meetbouten",
+        dataset="meetbouten",
+        schema="meetbouten",
         id_fields="identificatie,volgnummer",
         geojson_field="geometrie",
-        graphql_query=graphql_query,
+        graphql_query=json.dumps(graphql_query_new),
         http_conn_id="gob_graphql",
     )
+
+    rename_table = PostgresTableRenameOperator(
+        task_id=f"rename_table",
+        old_table_name="meetbouten_meetbouten_new",
+        new_table_name="meetbouten_meetbouten",
+    )
+
+data_load_task >> rename_table

--- a/src/dags/meetbouten.py
+++ b/src/dags/meetbouten.py
@@ -64,7 +64,7 @@ gql = """{
     }
 }
 """
-graphql_query = {"query": f"{gql}"}
+graphql_query = {"query": gql}
 dag_id = "meetbouten"
 owner = "gob"
 

--- a/src/dags/meetbouten.py
+++ b/src/dags/meetbouten.py
@@ -1,0 +1,21 @@
+from airflow import DAG
+from http_gob_operator import HttpGobOperator
+from common import default_args
+
+
+graphql_query = """{"query":"{  meetboutenMeetbouten($active: false, publiceerbaar: true) {    edges {      node {        identificatie         nabijNummeraanduiding {          edges {            node {              identificatie               volgnummer             }          }        }        locatie         status         vervaldatum         merk         xCoordinaatMuurvlak         yCoordinaatMuurvlak         windrichting         ligtInBouwblok {          edges {            node {              identificatie               volgnummer             }          }        }        ligtInBuurt {          edges {            node {              identificatie               volgnummer             }          }        }        ligtInStadsdeel {          edges {            node {              identificatie               volgnummer             }          }        }        geometrie         publiceerbaar       }    }  }}"}"""
+
+dag_id = "meetbouten"
+owner = "gob"
+
+with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
+
+    http_load_task = HttpGobOperator(
+        task_id="http_load_task",
+        endpoint="gob/graphql/streaming/",
+        schema="meetbouten_meetbouten",
+        id_fields="identificatie,volgnummer",
+        geojson_field="geometrie",
+        graphql_query=graphql_query,
+        http_conn_id="gob_graphql",
+    )

--- a/src/dags/meetbouten.py
+++ b/src/dags/meetbouten.py
@@ -1,11 +1,16 @@
 import json
 from airflow import DAG
 from postgres_rename_operator import PostgresTableRenameOperator
+from airflow.operators.postgres_operator import PostgresOperator
 from http_gob_operator import HttpGobOperator
 from common import default_args
 
 
-graphql_query = """{"query":"{  meetboutenMeetbouten($active: false, publiceerbaar: true) {    edges {      node {        identificatie         nabijNummeraanduiding {          edges {            node {              identificatie               volgnummer             }          }        }        locatie         status         vervaldatum         merk         xCoordinaatMuurvlak         yCoordinaatMuurvlak         windrichting         ligtInBouwblok {          edges {            node {              identificatie               volgnummer             }          }        }        ligtInBuurt {          edges {            node {              identificatie               volgnummer             }          }        }        ligtInStadsdeel {          edges {            node {              identificatie               volgnummer             }          }        }        geometrie         publiceerbaar       }    }  }}"}"""
+DROP_TMPL = """
+    {% for tablename in params.tablenames %}
+    DROP TABLE IF EXISTS {{ tablename }} CASCADE;
+    {% endfor %}
+"""
 
 
 gql = """{
@@ -59,12 +64,18 @@ gql = """{
     }
 }
 """
-graphql_query_new = {"query": f"{gql}"}
+graphql_query = {"query": f"{gql}"}
 dag_id = "meetbouten"
 owner = "gob"
 
 
 with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
+
+    drop_old_tmp_tables = PostgresOperator(
+        task_id="drop_old_tmp_tables",
+        sql=DROP_TMPL,
+        params=dict(tablenames=["meetbouten_meetbouten_new"]),
+    )
 
     data_load_task = HttpGobOperator(
         task_id="data_load_task",
@@ -73,7 +84,7 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
         schema="meetbouten",
         id_fields="identificatie,volgnummer",
         geojson_field="geometrie",
-        graphql_query=json.dumps(graphql_query_new),
+        graphql_query=json.dumps(graphql_query),
         http_conn_id="gob_graphql",
     )
 
@@ -83,4 +94,4 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
         new_table_name="meetbouten_meetbouten",
     )
 
-data_load_task >> rename_table
+drop_old_tmp_tables >> data_load_task >> rename_table

--- a/src/dags/meetbouten.py
+++ b/src/dags/meetbouten.py
@@ -69,7 +69,7 @@ dag_id = "meetbouten"
 owner = "gob"
 
 
-with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
+with DAG(dag_id, default_args={"owner": owner, **default_args}) as dag:
 
     drop_old_tmp_tables = PostgresOperator(
         task_id="drop_old_tmp_tables",

--- a/src/plugins/http_gob_operator.py
+++ b/src/plugins/http_gob_operator.py
@@ -46,7 +46,7 @@ class HttpGobOperator(BaseOperator):
         self.http_conn_id = http_conn_id
         self.endpoint = endpoint
         self.http_conn_id = http_conn_id
-        self.db_table_name = "_".join([self.dataset, self.schema])
+        self.db_table_name = f"{self.dataset}_{self.schema}"
         super().__init__(*args, **kwargs)
 
     def _fetch_params(self):

--- a/src/plugins/http_gob_operator.py
+++ b/src/plugins/http_gob_operator.py
@@ -1,0 +1,92 @@
+import shutil
+from pathlib import Path
+from environs import Env
+from tempfile import TemporaryDirectory
+
+from airflow.models.baseoperator import BaseOperator
+from airflow.utils.decorators import apply_defaults
+from airflow.hooks.postgres_hook import PostgresHook
+from schematools.importer.ndjson import NDJSONImporter
+from schematools.utils import schema_def_from_url
+
+from http_params_hook import HttpParamsHook
+
+env = Env()
+SCHEMA_URL = env("SCHEMA_URL")
+
+
+class HttpGobOperator(BaseOperator):
+    """ Operator for fetching data from Gob
+    """
+
+    # template_fields = [
+    #     "endpoint",
+    #     "data",
+    #     "headers",
+    # ]
+
+    @apply_defaults
+    def __init__(
+        self,
+        endpoint: str,
+        schema: str,
+        id_fields: tuple,
+        geojson_field: str,
+        graphql_query: str,
+        http_conn_id="http_default",
+        *args,
+        **kwargs,
+    ) -> None:
+        self.schema = (schema,)
+        self.id_fields = id_fields
+        self.geojson_field = geojson_field
+        self.graphql_query = graphql_query
+        self.http_conn_id = http_conn_id
+        self.endpoint = endpoint
+        self.http_conn_id = http_conn_id
+        super().__init__(*args, **kwargs)
+
+    def _fetch_params(self):
+        return {
+            "condens": "node,edges,id",
+            "lowercase": "true",
+            "flatten": "true",
+            "id": self.id_fields,
+            "schema": self.schema,
+            "geojson": self.geojson_field,
+        }
+
+    def execute(self, context):
+        with TemporaryDirectory() as temp_dir:
+            tmp_file = Path(temp_dir) / "out.ndjson"
+            # self.tmp_file.parents[0].mkdir(parents=True, exist_ok=True)
+            http = HttpParamsHook(http_conn_id=self.http_conn_id, method="POST")
+
+            self.log.info("Calling GOB graphql endpoint")
+            response = http.run(
+                self.endpoint,
+                self._fetch_params(),
+                self.graphql_query,
+                {"Content-Type": "application/x-ndjson"},
+                extra_options={"stream": True},
+            )
+            # When content is encoded (gzip etc.) we need this
+            # response.raw.read = functools.partial(response.raw.read, decode_content=True)
+            # Use a tempfolder
+            with tmp_file.open("wb") as wf:
+                shutil.copyfileobj(response.raw, wf)
+
+            # And use the ndjson importer from schematools, give it a tmp tablename
+            # we know the schema, can be an input param (schema_def_from_url function)
+            pg_hook = PostgresHook()
+            schema = schema_def_from_url(SCHEMA_URL, "meetbouten")
+            importer = NDJSONImporter(
+                schema, pg_hook.get_sqlalchemy_engine(), logger=self.log
+            )
+
+            importer.load_file(
+                tmp_file,
+                table_name=self.schema,
+                db_table_name=f"{self.schema}_tmp",
+                truncate=True,  # when reexecuting the same task
+            )

--- a/src/plugins/http_params_hook.py
+++ b/src/plugins/http_params_hook.py
@@ -1,0 +1,75 @@
+import requests
+from airflow.hooks.http_hook import HttpHook
+
+
+class HttpParamsHook(HttpHook):
+    """ Unfortunately, the default HttpHook makes it impossible
+        to combine query params with a payload in the body, so
+        we need a subclass with a slightly modified copy of the
+        run method
+    """
+
+    def run(
+        self,
+        endpoint,
+        params=None,
+        data=None,
+        headers=None,
+        extra_options=None,
+        **request_kwargs
+    ):
+        r"""
+        Performs the request
+
+        :param endpoint: the endpoint to be called i.e. resource/v1/query?
+        :type endpoint: str
+        :param params: query parameters
+        :type data: dict
+        :param data: payload to be uploaded or request parameters
+        :type data: dict
+        :param headers: additional headers to be passed through as a dictionary
+        :type headers: dict
+        :param extra_options: additional options to be used when executing the request
+            i.e. {'check_response': False} to avoid checking raising exceptions on non
+            2XX or 3XX status codes
+        :type extra_options: dict
+        :param  \**request_kwargs: Additional kwargs to pass when creating a request.
+            For example, ``run(json=obj)`` is passed as ``requests.Request(json=obj)``
+        """
+        extra_options = extra_options or {}
+
+        session = self.get_conn(headers)
+
+        if (
+            self.base_url
+            and not self.base_url.endswith("/")
+            and endpoint
+            and not endpoint.startswith("/")
+        ):
+            url = self.base_url + "/" + endpoint
+        else:
+            url = (self.base_url or "") + (endpoint or "")
+
+        req = None
+        if self.method == "GET":
+            # GET uses params
+            req = requests.Request(
+                self.method, url, params=params, headers=headers, **request_kwargs
+            )
+        elif self.method == "HEAD":
+            # HEAD doesn't use params
+            req = requests.Request(self.method, url, headers=headers, **request_kwargs)
+        else:
+            # Others use data
+            req = requests.Request(
+                self.method,
+                url,
+                data=data,
+                params=params,
+                headers=headers,
+                **request_kwargs
+            )
+
+        prepped_request = session.prepare_request(req)
+        self.log.info("Sending '%s' to url: %s", self.method, url)
+        return self.run_and_check(session, prepped_request, extra_options)

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-amsterdam-schema-tools == 0.8.2
+amsterdam-schema-tools == 0.8.8
 apache-airflow[crypto,postgres,sentry] == 1.10.10
 cattrs == 0.9
 datapunt-objectstore == 2019.4.8

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 alembic==1.4.2            # via apache-airflow
-amsterdam-schema-tools==0.8.2  # via -r requirements.in
+amsterdam-schema-tools==0.8.8  # via -r requirements.in
 apache-airflow[crypto,postgres,sentry]==1.10.10  # via -r requirements.in
 apispec[yaml]==1.3.3      # via flask-appbuilder
 argcomplete==1.11.1       # via apache-airflow

--- a/src/scripts/run.sh
+++ b/src/scripts/run.sh
@@ -48,8 +48,14 @@ airflow connections --add  --conn_id verlichting_conn_id \
     --conn_host https://asd2.techtek.eu \
     --conn_type http
 
+airflow connections --delete --conn_id gob_graphql
+airflow connections --add  --conn_id gob_graphql \
+    --conn_host https://acc.api.data.amsterdam.nl \
+    --conn_type http
+
 # airflow variables -i vars/vars.json &
 # airflow scheduler &
 # airflow webserver
 airflow variables -i vars/vars.json
+# sleep infinity
 /usr/local/bin/supervisord --config /usr/local/airflow/etc/supervisord.conf


### PR DESCRIPTION
Meetbouten data wordt als ndjson binnengehaald van Gob endpoint. Gob gebruikt request params + payload body door elkaar voor een POST request. Standaard HttpHook in Airflow kan hier niet mee omgaan, dus was een getweakede copy nodig.
De binnengehaald ndjson wordt mbv. de NDJSON importer uit schematools ingelezen.
Enkele stappen zijn samengebracht in een operator "HttpGobOperator" die de basis gaat bieden voor meer Gob-dataset integraties.