### PR TITLE
Riooleidingen

### DIFF
--- a/src/dags/beschermde_stadsdorpsgezichten.py
+++ b/src/dags/beschermde_stadsdorpsgezichten.py
@@ -49,9 +49,11 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
         username="admin",
     )
 
-    drop_and_create_schema = PostgresOperator(
-        task_id="drop_and_create_schema",
-        sql="DROP SCHEMA IF EXISTS pte CASCADE; CREATE SCHEMA pte;",
+    # XXX Potentially dangerous, because more team-ruimte tables
+    # will be in schema pte, make more specific
+    drop_imported_table = PostgresOperator(
+        task_id="drop_imported_table",
+        sql="DROP TABLE IF EXISTS pte.beschermde_stadsdorpsgezichten CASCADE",
     )
 
     swift_load_task = SwiftLoadSqlOperator(
@@ -104,7 +106,7 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
 
 (
     slack_at_start
-    >> drop_and_create_schema
+    >> drop_imported_table
     >> swift_load_task
     >> correct_geo
     >> multi_check

--- a/src/dags/graphql/meetbouten-rollagen.graphql
+++ b/src/dags/graphql/meetbouten-rollagen.graphql
@@ -1,0 +1,17 @@
+{
+  meetboutenRollagen($active: false) {
+    edges {
+      node {
+        identificatie 
+        isGemetenVanBouwblok {
+          edges {
+            node {
+              identificatie 
+              volgnummer 
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/dags/riool.py
+++ b/src/dags/riool.py
@@ -1,0 +1,102 @@
+import operator
+from airflow import DAG
+from airflow.operators.postgres_operator import PostgresOperator
+from swift_load_sql_operator import SwiftLoadSqlOperator
+from provenance_rename_operator import ProvenanceRenameOperator
+from postgres_check_operator import (
+    PostgresMultiCheckOperator,
+    COUNT_CHECK,
+    COLNAMES_CHECK,
+    GEO_CHECK,
+)
+
+from common import (
+    default_args,
+    MessageOperator,
+    DATAPUNT_ENVIRONMENT,
+    slack_webhook_token,
+)
+
+DATASTORE_TYPE = (
+    "acceptance" if DATAPUNT_ENVIRONMENT == "development" else DATAPUNT_ENVIRONMENT
+)
+
+RENAME_TABLES_SQL = """
+    DROP TABLE IF EXISTS public.rioolleidingen_rioolknopen;
+    ALTER TABLE pte.rioolknopen SET SCHEMA public;
+    ALTER TABLE rioolknopen
+        RENAME TO rioolleidingen_rioolknopen;
+"""
+
+dag_id = "riool"
+owner = "team_ruimte"
+
+with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
+
+    checks = []
+
+    slack_at_start = MessageOperator(
+        task_id="slack_at_start",
+        http_conn_id="slack",
+        webhook_token=slack_webhook_token,
+        message=f"Starting {dag_id} ({DATAPUNT_ENVIRONMENT})",
+        username="admin",
+    )
+
+    drop_table = PostgresOperator(
+        task_id="drop_table",
+        sql=[
+            "DROP TABLE IF EXISTS pte.kel_rioolknopen CASCADE",
+            "DROP TABLE IF EXISTS pte.rioolknopen CASCADE",
+        ],
+    )
+
+    swift_load_task = SwiftLoadSqlOperator(
+        task_id="swift_load_task",
+        container="Dataservices",
+        object_id=f"riool/{DATASTORE_TYPE}/" "riool.zip",
+        swift_conn_id="objectstore_dataservices",
+    )
+
+    # XXX When second dataset table is available, add extra checks
+    checks.append(
+        COUNT_CHECK.make_check(
+            check_id="count_check",
+            pass_value=180000,
+            params=dict(table_name="pte.kel_rioolknopen"),
+            result_checker=operator.ge,
+        )
+    )
+
+    # XXX Get colnames from schema (provenance info)
+    checks.append(
+        COLNAMES_CHECK.make_check(
+            check_id="colname_check",
+            parameters=["pte", "kel_rioolknopen"],
+            pass_value={"objnr", "knoopnr", "objectsoor", "type_funde", "geometrie",},
+            result_checker=operator.ge,
+        )
+    )
+
+    checks.append(
+        GEO_CHECK.make_check(
+            check_id="geo_check",
+            params=dict(
+                table_name="pte.kel_rioolknopen",
+                geo_column="geometrie",
+                geotype="POINT",
+            ),
+            pass_value=1,
+        )
+    )
+
+    multi_check = PostgresMultiCheckOperator(task_id="multi_check", checks=checks)
+
+    rename_columns = ProvenanceRenameOperator(
+        task_id="rename_columns", dataset_name="rioolleidingen", pg_schema="pte"
+    )
+
+    rename_table = PostgresOperator(task_id="rename_table", sql=RENAME_TABLES_SQL,)
+
+
+slack_at_start >> drop_table >> swift_load_task >> multi_check >> rename_columns >> rename_table

--- a/src/plugins/provenance_rename_operator.py
+++ b/src/plugins/provenance_rename_operator.py
@@ -1,0 +1,89 @@
+from collections import defaultdict
+from environs import Env
+from airflow.models.baseoperator import BaseOperator
+from airflow.hooks.postgres_hook import PostgresHook
+from airflow.utils.decorators import apply_defaults
+from schematools.utils import schema_def_from_url, to_snake_case
+
+env = Env()
+SCHEMA_URL = env("SCHEMA_URL")
+
+
+class ProvenanceRenameOperator(BaseOperator):
+    @apply_defaults
+    def __init__(
+        self,
+        dataset_name,
+        pg_schema="public",
+        postgres_conn_id="postgres_default",
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.postgres_conn_id = postgres_conn_id
+        self.dataset_name = dataset_name
+        self.pg_schema = pg_schema
+
+    def _snake_tablenames(self, tablenames):
+        return ", ".join((f"'{to_snake_case(tn)}'" for tn in tablenames))
+
+    def _get_existing_tables(self, pg_hook, tables, pg_schema="public"):
+        if not tables:
+            return []
+        table_lookup = {}
+        for table in tables:
+            real_tablename = table.get("provenance", table.id)
+            table_lookup[real_tablename] = table
+
+        snaked_tablenames_str = self._snake_tablenames(table_lookup.keys())
+        rows = pg_hook.get_records(
+            f"""
+                    SELECT tablename FROM pg_tables
+                    WHERE schemaname = '{pg_schema}' AND tablename IN ({snaked_tablenames_str})
+                """
+        )
+        return [(row["tablename"], table_lookup[row["tablename"]]) for row in rows]
+
+    def _get_existing_columns(self, pg_hook, snaked_tablenames, pg_schema="public"):
+        snaked_tablenames_str = self._snake_tablenames(snaked_tablenames)
+        rows = pg_hook.get_records(
+            f"""
+                    SELECT table_name, column_name FROM information_schema.columns
+                    WHERE table_schema = '{pg_schema}' AND table_name IN ({snaked_tablenames_str})
+                """,
+        )
+        table_columns = defaultdict(set)
+        for row in rows:
+            table_columns[row["table_name"]].add(row["column_name"])
+        return table_columns
+
+    def execute(self, context=None):
+        dataset = schema_def_from_url(SCHEMA_URL, self.dataset_name)
+        pg_hook = PostgresHook(postgres_conn_id=self.postgres_conn_id)
+        sqls = []
+        existing_tables_info = self._get_existing_tables(
+            pg_hook, dataset.tables, pg_schema=self.pg_schema
+        )
+        snaked_tablenames = [stn for stn, _ in existing_tables_info]
+        for snaked_tablename, table in existing_tables_info:
+            existing_columns = self._get_existing_columns(
+                pg_hook, snaked_tablenames, pg_schema=self.pg_schema
+            )
+            for field in table.fields:
+                provenance = field.get("provenance")
+                if provenance is not None:
+                    snaked_field_name = to_snake_case(field.name)
+                    if provenance in existing_columns[snaked_tablename]:
+                        sqls.append(
+                            f"""ALTER TABLE {self.pg_schema}.{snaked_tablename}
+                                RENAME COLUMN {provenance} TO {snaked_field_name}"""
+                        )
+
+            provenance = table.get("provenance")
+            if provenance is not None:
+                sqls.append(
+                    f"""ALTER TABLE IF EXISTS {self.pg_schema}.{snaked_tablename}
+                            RENAME TO {table.id}"""
+                )
+
+        pg_hook.run(sqls)


### PR DESCRIPTION
De riool dataset. Op dit moment is alleen nog de tabel rioolknopen beschikbaar.

Data wordt aangeleverd als postgresql *.backup en wordt ingelezen vanaf de objectstore (vergelijkbaar met beschermde stads- en dorpsgezichten). Er worden enkele checks op de data uitgevoerd, waarna de kolommen worden hernoemd naar de juiste amsterdam schema veldnamen obv. de provenance info.
