### PR TITLE
Timezone settings for Airflow webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ The airflow webserver is running at http://localhost:8080/
 The webserver UI is protected with a password, the associated admin user needs to be created
 once inside of the PostgreSQL database using this command:
 
-    docker-compose exec airflow python scripts/mkuser.py <username> <e-mail address user>
+    1. log in the airflow container: docker exec -it airflow bash
+    2. create admin user: airflow create_user -r Admin -u admin -e admin@example.com -f admin -l admin -p test
+
+    # Since activating the timezone on the Airflow GUI, this doesn't work anymore and is therefore comment out
+    # docker-compose exec airflow python scripts/mkuser.py <username> <e-mail address user>
+
 
 This script prompts for a password and stores the credentials in the PostgreSQL database.
 To create a superuser, add the `--superuser` flag to the command.

--- a/src/config/airflow.cfg
+++ b/src/config/airflow.cfg
@@ -216,6 +216,9 @@ default_hive_mapred_queue =
 # base_url = https://acc.airflowlight.data.amsterdam.nl/dataservices
 base_url = http://localhost:8080
 
+# GUI timezone
+default_ui_timezone = Europe/Amsterdam
+
 # The ip specified when starting the web server
 web_server_host = 0.0.0.0
 
@@ -300,7 +303,7 @@ hide_paused_dags_by_default = False
 page_size = 100
 
 # Use FAB-based webserver with RBAC feature
-rbac = False
+rbac = True
 
 # Define the color of navigation bar
 navbar_color = #007A87


### PR DESCRIPTION
In the Airflow UI the Europe/Amsterdam timezone was not visible. Instead the default timezone UTC was diplayed.
In order to show the definied timezone two variabeles needs to be changed:

Under the webserver section:

- rbac (Role Based Access Control) = True (deafult = False)
- default_ui_timezone = Europe/Amsterdam (default is not present)

The effect is:

- Correct timezone is displayed in Airflow UI
- Adding users must be done with the airflow create_user cmd