### PR TITLE
[DS-486] removed drop schema because of collision

### DIFF
--- a/src/dags/huishoudelijkafval.py
+++ b/src/dags/huishoudelijkafval.py
@@ -42,6 +42,8 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
         container="Dataservices",
         object_id=f"afval_huishoudelijk/{DATASTORE_TYPE}/" "afval_api.zip",
         swift_conn_id="objectstore_dataservices",
+        # optionals
+        # db_target_schema will create the schema if not present 
         db_target_schema="pte",
     )
 

--- a/src/plugins/provenance_drop_from_schema_operator.py
+++ b/src/plugins/provenance_drop_from_schema_operator.py
@@ -42,3 +42,4 @@ class ProvenanceDropFromSchemaOperator(BaseOperator):
         ]
 
         pg_hook.run(sqls)
+

--- a/src/plugins/provenance_rename_operator.py
+++ b/src/plugins/provenance_rename_operator.py
@@ -49,21 +49,27 @@ class ProvenanceRenameOperator(BaseOperator):
             table_lookup[to_snake_case(real_tablename)] = table
 
         snaked_tablenames_str = self._snake_tablenames(table_lookup.keys())
+        print("row snaked_tablenames_str", snaked_tablenames_str)
         rows = pg_hook.get_records(
             f"""
                 SELECT tablename FROM pg_tables
-                WHERE schemaname = '{pg_schema}' AND tablename IN ({snaked_tablenames_str})
+                WHERE schemaname = '{pg_schema}' AND 2=2 AND tablename IN ({snaked_tablenames_str})
             """
         )
-
+        print("row start", rows)
+        for row in rows:
+            print("row", row["tablename"])
+        print("row end")
+       
         return {row["tablename"]: table_lookup[row["tablename"]] for row in rows}
 
     def _get_existing_columns(self, pg_hook, snaked_tablenames, pg_schema="public"):
         snaked_tablenames_str = self._snake_tablenames(snaked_tablenames)
+        print("the snaked_tabels str ", snaked_tablenames_str)
         rows = pg_hook.get_records(
             f"""
                 SELECT table_name, column_name FROM information_schema.columns
-                WHERE table_schema = '{pg_schema}' AND table_name IN ({snaked_tablenames_str})
+                WHERE table_schema = '{pg_schema}' AND 1=1 AND table_name IN ({snaked_tablenames_str})
             """
         )
         table_columns = defaultdict(set)

--- a/src/plugins/psql_cmd_hook.py
+++ b/src/plugins/psql_cmd_hook.py
@@ -18,28 +18,21 @@ class PsqlCmdHook(BaseHook):
         connection_uri = BaseHook.get_connection(self.conn_id).get_uri().split("?")[0]
 
         if self.db_target_schema:
-            self.refresh_schema(self.db_target_schema, connection_uri)
+            self.recreate_schema(self.db_target_schema, connection_uri)
                 
         self.log.info("Running sql files: %s", sql_files)
         subprocess.run(
             f'cat {paths} | psql "{connection_uri}" {pg_params}', shell=True, check=True
         )
-
     
-    def refresh_schema(self, db_target_schema, connection_uri):
+    def recreate_schema(self, db_target_schema, connection_uri):
         """
-        If a schema is defined at the creation of the instance, it will drop and create the schema (if not exists)
-        """
+        If a schema is defined at the creation of the instance, it will create the schema (if not exists)
+        """        
         
-        self.log.info(f"Drop the DB target schema '{db_target_schema}' if present")
-        subprocess.run(
-                f'echo "DROP SCHEMA IF EXISTS {db_target_schema} CASCADE" | psql "{connection_uri}" {pg_params}'
-                ,shell=True
-                ,check=True
-            )
         self.log.info(f"Creating the DB target schema '{db_target_schema}' if not present")
         subprocess.run(
                 f'echo "CREATE SCHEMA IF NOT EXISTS {db_target_schema}" | psql "{connection_uri}" {pg_params}'
                 ,shell=True
                 ,check=True
-            )
+            )   


### PR DESCRIPTION
Due to the use of the same schema (PTE) in multiple dags (source files), the drop schema is removed from the logic to avoid collision. 

The drop schema was introduced to cope with the situation that the schema definition had not (yet) specified a table that was already given in the source files. Due to the database dump import the unspecified tables remained in the schema and where not deleted. The deletion is base on the schema specification.

In order to avoid an error between schema definition and source files, it is possible to list the tables that are not yet specified in the schema to be removed after each run.