### PR TITLE
[DS-486] removed drop schema because of collision

### DIFF
--- a/src/dags/huishoudelijkafval.py
+++ b/src/dags/huishoudelijkafval.py
@@ -32,8 +32,11 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
     )
 
     # 2. Drop tables in target schema PTE (schema which orginates from the DB dump file, see next step)
+    #    based upon presence in the Amsterdam schema definition
     drop_tables = ProvenanceDropFromSchemaOperator(
-        task_id="drop_tables", dataset_name="huishoudelijkafval", pg_schema="pte",
+        task_id="drop_tables", 
+        dataset_name="huishoudelijkafval", 
+        pg_schema="pte",
     )
 
     # 3. load the dump file
@@ -42,7 +45,9 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
         container="Dataservices",
         object_id=f"afval_huishoudelijk/{DATASTORE_TYPE}/" "afval_api.zip",
         swift_conn_id="objectstore_dataservices",
-        db_target_schema="pte",
+        # optionals
+        # db_target_schema will create the schema if not present 
+        db_target_schema="pte",      
     )
 
     # 4. Make the provenance translations

--- a/src/plugins/psql_cmd_hook.py
+++ b/src/plugins/psql_cmd_hook.py
@@ -18,28 +18,21 @@ class PsqlCmdHook(BaseHook):
         connection_uri = BaseHook.get_connection(self.conn_id).get_uri().split("?")[0]
 
         if self.db_target_schema:
-            self.refresh_schema(self.db_target_schema, connection_uri)
+            self.recreate_schema(self.db_target_schema, connection_uri)
                 
         self.log.info("Running sql files: %s", sql_files)
         subprocess.run(
             f'cat {paths} | psql "{connection_uri}" {pg_params}', shell=True, check=True
         )
-
     
-    def refresh_schema(self, db_target_schema, connection_uri):
+    def recreate_schema(self, db_target_schema, connection_uri):
         """
-        If a schema is defined at the creation of the instance, it will drop and create the schema (if not exists)
-        """
+        If a schema is defined at the creation of the instance, it will create the schema (if not exists)
+        """        
         
-        self.log.info(f"Drop the DB target schema '{db_target_schema}' if present")
-        subprocess.run(
-                f'echo "DROP SCHEMA IF EXISTS {db_target_schema} CASCADE" | psql "{connection_uri}" {pg_params}'
-                ,shell=True
-                ,check=True
-            )
         self.log.info(f"Creating the DB target schema '{db_target_schema}' if not present")
         subprocess.run(
                 f'echo "CREATE SCHEMA IF NOT EXISTS {db_target_schema}" | psql "{connection_uri}" {pg_params}'
                 ,shell=True
                 ,check=True
-            )
+            )   

--- a/src/plugins/swift_load_sql_operator.py
+++ b/src/plugins/swift_load_sql_operator.py
@@ -32,7 +32,7 @@ class SwiftLoadSqlOperator(BaseOperator):
         self.container = container
         self.object_id = object_id
         self.swift_conn_id = swift_conn_id
-        self.db_target_schema = db_target_schema
+        self.db_target_schema = db_target_schema       
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
@@ -48,4 +48,3 @@ class SwiftLoadSqlOperator(BaseOperator):
                 filenames = [object_path]
             psql_cmd_hook = PsqlCmdHook(db_target_schema=self.db_target_schema)
             psql_cmd_hook.run(Path(tmpdirname) / fn for fn in filenames)
-


### PR DESCRIPTION
Due to the use of the same schema (PTE) in multiple dags (source files), the drop schema is removed from the logic to avoid collision.

The drop schema was introduced to cope with the situation that the schema definition had not (yet) specified a table that was already given in the source files. Due to the database dump import the unspecified tables remained in the schema and where not deleted. The deletion is base on the schema specification.

In order to avoid an error between schema definition and source files, it is possible to list the tables that are not yet specified in the schema to be removed after each run.