### PR TITLE
Make GOB graphql endpoints configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       AIRFLOW_CONN_BOUWSTROOMPUNTEN_PASSWD: ${dataservices_bouwstroompunten_passwd}
       AIRFLOW_CONN_BOUWSTROOMPUNTEN_USER: ${dataservices_bouwstroompunten_user}
       AIRFLOW_CONN_BOUWSTROOMPUNTEN_BASE_URL: "https://maps.nrgaccounting.nl"
+      GOB_PUBLIC_ENDPOINT: "gob/graphql/streaming/"
+      GOB_SECURE_ENDPOINT: "gob/secure/graphql/streaming/"
       FERNET_KEY: ${FERNET_KEY}
       AIRFLOW_LOGGING_LEVEL: ${AIRFLOW_LOGGING_LEVEL:-WARN}
       AIRFLOW__WEBSERVER__BASE_URL: http://localhost:8080/

--- a/src/dags/graphql/brk-aantekeningenkadastraleobjecten/args.json
+++ b/src/dags/graphql/brk-aantekeningenkadastraleobjecten/args.json
@@ -1,5 +1,4 @@
 {
-  "extra_kwargs": {"endpoint": "gob/secure/graphql/streaming/", "protected": true},
+  "extra_kwargs": {"protected": true},
   "schedule_start_hour_offset": 6
 }
-

--- a/src/dags/graphql/brk-aantekeningenrechten/args.json
+++ b/src/dags/graphql/brk-aantekeningenrechten/args.json
@@ -1,4 +1,4 @@
 {
-  "extra_kwargs": {"endpoint": "gob/secure/graphql/streaming/", "protected": true},
+  "extra_kwargs": {"protected": true},
   "schedule_start_hour_offset": 6
 }

--- a/src/dags/graphql/brk-kadastraleobjecten/args.json
+++ b/src/dags/graphql/brk-kadastraleobjecten/args.json
@@ -1,9 +1,7 @@
 {
   "extra_kwargs": {
-    "endpoint": "gob/secure/graphql/streaming/",
     "geojson_field": "geometrie,plaatscoordinaten,bijpijlingGeometrie",
     "protected": true
   },
   "schedule_start_hour_offset": 6
 }
-

--- a/src/dags/graphql/brk-kadastralesubjecten/args.json
+++ b/src/dags/graphql/brk-kadastralesubjecten/args.json
@@ -1,5 +1,4 @@
 {
-  "extra_kwargs": {"endpoint": "gob/secure/graphql/streaming/", "protected": true},
+  "extra_kwargs": {"protected": true},
   "schedule_start_hour_offset": 6
 }
-

--- a/src/dags/graphql/brk-stukdelen/args.json
+++ b/src/dags/graphql/brk-stukdelen/args.json
@@ -1,10 +1,8 @@
 {
   "extra_kwargs": {
-    "endpoint": "gob/secure/graphql/streaming/",
     "batch_size": 100,
     "protected": true
   },
 
   "schedule_start_hour_offset": 6
 }
-

--- a/src/dags/graphql/brk-tenaamstellingen/args.json
+++ b/src/dags/graphql/brk-tenaamstellingen/args.json
@@ -1,5 +1,4 @@
 {
-  "extra_kwargs": {"endpoint": "gob/secure/graphql/streaming/", "protected": true},
+  "extra_kwargs": {"protected": true},
   "schedule_start_hour_offset": 6
 }
-

--- a/src/dags/graphql/brk-zakelijkerechten/args.json
+++ b/src/dags/graphql/brk-zakelijkerechten/args.json
@@ -1,5 +1,4 @@
 {
-  "extra_kwargs": {"endpoint": "gob/secure/graphql/streaming/", "protected": true},
+  "extra_kwargs": {"protected": true},
   "schedule_start_hour_offset": 6
 }
-


### PR DESCRIPTION
GOB wants to change these endpoints and there will be a considerable
timegap between changing ACC and PRD. By making the endpoints
configurable with an env. var, the Openstack ansible configuration
can be used to manage this change-process.