### PR TITLE
[DS-563] add permissions operator

### DIFF
--- a/src/dags/airflow_db_permissions.py
+++ b/src/dags/airflow_db_permissions.py
@@ -1,0 +1,42 @@
+import logging
+
+from airflow import DAG
+from airflow.models import Variable
+from postgres_permissions_operator import PostgresPermissionsOperator
+
+from common import (
+    default_args,
+    slack_webhook_token,
+    DATAPUNT_ENVIRONMENT,
+    MessageOperator,
+)
+
+dag_id = "airflow_db_permissions"
+logger = logging.getLogger(__name__)
+
+with DAG(
+    dag_id,
+    default_args=default_args,
+    schedule_interval="*/15 * * * *",
+    catchup=False,
+    description=f"set grants on database objects to database roles based upon schema auth definition, based upon successfully executed dags within specified time window.",
+) as dag:
+
+    # 1. Post info message on slack
+    slack_at_start = MessageOperator(
+        task_id="slack_at_start",
+        http_conn_id="slack",
+        webhook_token=slack_webhook_token,
+        message=f"Starting {dag_id} ({DATAPUNT_ENVIRONMENT})",
+        username="admin",
+    )
+
+    # 2. Add grants (in batch mode)
+    # seeks for dags that successfully executed within time window
+    # default time window is set on 30 min.
+    # beware: currently the logic assumes dag_id == dataset name
+    # TODO look for possibility to use other then dag_id as dataset name
+    grants = PostgresPermissionsOperator(task_id="grants", batch_ind=True)
+
+# FLOW
+slack_at_start >> grants

--- a/src/plugins/postgres_permissions_operator.py
+++ b/src/plugins/postgres_permissions_operator.py
@@ -1,0 +1,171 @@
+import logging
+import pendulum
+
+from datetime import timedelta
+from environs import Env
+
+from schematools.utils import schema_defs_from_url
+from schematools.permissions import apply_schema_and_profile_permissions
+from schematools.cli import _get_engine
+
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.dagrun import DagRun
+from airflow.settings import Session
+
+env = Env()
+
+# split is used to remove url params, if exists. For database connection the url params must be omitted.
+default_db_conn = env("AIRFLOW_CONN_POSTGRES_DEFAULT").split("?")[0]
+default_schema_url = env("SCHEMA_URL")
+datapunt_evironment = env("DATAPUNT_ENVIRONMENT")
+
+
+class PostgresPermissionsOperator(BaseOperator):
+    """
+    This operator executes DB grants << on >> DB tables / fields << to >> DB roles.
+
+    It can be envoked based upon a single dataset or a list of datasets. It uses the dag_id to identify the dataset.
+
+    The DB roles are derived from the AUTH element as defined in the Amsterdam schema.
+    When no AUTH element is provided in the Amsterdam schema, it default to DB role SCOPE_OPENBAAR.
+    DB users can be assigned as member to the DB roles to get access to DB objects.
+
+    Caveat:
+    When objects are dropped in the DB, the grants to the roles are removed as well.
+    This results that grants must be (re)applied again to the roles.
+
+    An other way to deal with is, is to update tables based upon the pgcomparator_cdc_operator.py.
+    Which detects differences between source and target table, and upserts the target table if nessacery
+    in stead of dropping, recreating the target table and inserting the records on each run.
+    """
+
+    def __init__(
+        self,
+        batch_ind=False,
+        batch_timewindow="0:30",
+        dag_name=None,
+        db_conn=default_db_conn,
+        schema_url=default_schema_url,
+        db_schema="public",
+        profiles=None,
+        role="AUTO",
+        scope=None,
+        dry_run=False,
+        create_roles=True,
+        revoke=False,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.batch_ind = batch_ind
+        self.batch_timewindow = batch_timewindow
+        self.dataset_name = dag_name
+        self.db_conn = db_conn
+        self.schema_url = schema_url
+        self.db_schema = db_schema
+        self.profiles = profiles
+        self.role = role
+        self.scope = scope
+        self.dry_run = dry_run
+        self.create_roles = create_roles
+        self.revoke = revoke
+
+    def execute(self, context=None):
+        """Executes the 'apply_schema_and_profile_permissions' method from schema-tools to set the database permissions on objects to roles"""
+
+        # setup logger so output can be added to the Airflow logs
+        logger = logging.getLogger(__name__)
+
+        # setup database connection where the database objects are present
+        engine = _get_engine(self.db_conn)
+
+        # Option ONE: batch grant
+        if self.batch_ind:
+
+            # get current datetime and make it aware of the TZ (mandatory)
+            now = pendulum.now("Europe/Amsterdam")
+
+            # calculate the delta between current datetime and specified time window
+            time_window_hour = int(self.batch_timewindow.split(':')[0])
+            time_window_minutes = int(self.batch_timewindow.split(':')[1])
+            delta = now - timedelta(hours=time_window_hour, minutes=time_window_minutes)
+
+            logger.info(f"the time window is set starting at: {delta} till now")
+
+            # setup an Airflow session to access Airflow repository data
+            session = Session()
+
+            # get list of dags that meet time window and state outcome
+            # it uses the Airflow DagRun class to get data
+            executed_dags_after_delta = [
+                dag.dag_id
+                for dag in session.query(DagRun)
+                .filter(DagRun.execution_date > delta)
+                .filter(DagRun._state == "success")
+                # exclude the dag itself that calls this batch grant method
+                .filter((DagRun.dag_id != "airflow_db_permissions"))
+            ]
+
+
+            if executed_dags_after_delta:
+
+                for dataset_name in executed_dags_after_delta:
+
+                    logger.info(
+                            f"set grants for {dataset_name}"
+                        )
+
+                    try:
+                        ams_schema = schema_defs_from_url(
+                            schemas_url=self.schema_url,
+                            dataset_name=dataset_name,
+                        )
+
+                        apply_schema_and_profile_permissions(
+                            engine=engine,
+                            pg_schema=self.db_schema,
+                            ams_schema=ams_schema,
+                            profiles=self.profiles,
+                            role=self.role,
+                            scope=self.scope,
+                            dry_run=self.dry_run,
+                            create_roles=self.create_roles,
+                            revoke=self.revoke,
+                        )
+
+                    except:
+                        logger.error(
+                            f"Could not get data schema for {dataset_name}"
+                        )
+                        continue
+
+            else:
+                logger.error(
+                    f"Nothing to grant, no finished dags detected within time window of {self.batch_timewindow}."
+                )
+
+        # Option TWO: grant on single dataset (can be used as a final step within a dag run)
+        elif self.dataset_name and not self.batch_ind:
+
+            try:
+                ams_schema = schema_defs_from_url(
+                    schemas_url=self.schema_url, dataset_name=self.dataset_name
+                )
+
+                apply_schema_and_profile_permissions(
+                    engine=engine,
+                    pg_schema=self.db_schema,
+                    ams_schema=ams_schema,
+                    profiles=self.profiles,
+                    role=self.role,
+                    scope=self.scope,
+                    dry_run=self.dry_run,
+                    create_roles=self.create_roles,
+                    revoke=self.revoke,
+                )
+
+            except:
+                logger.error(
+                    f"Could not get data schema for {self.dataset_name}"
+                )
+                pass

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-amsterdam-schema-tools == 0.16.4
+amsterdam-schema-tools == 0.16.6
 apache-airflow[crypto,postgres,sentry] == 1.10.10
 cattrs == 0.9
 datapunt-objectstore == 2019.4.8

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 alembic==1.4.2            # via apache-airflow
-amsterdam-schema-tools==0.16.4  # via -r requirements.in
+amsterdam-schema-tools==0.16.6  # via -r requirements.in
 apache-airflow[crypto,postgres,sentry]==1.10.10  # via -r requirements.in
 apispec[yaml]==1.3.3      # via flask-appbuilder
 argcomplete==1.11.1       # via apache-airflow


### PR DESCRIPTION
Added a permissions operator that uses permissions logic from schema-tools. And added a permissions DAG to check if there are executed DAG's within a time window.

Alternative would be to set the permissions as last step within each dag. That would be certainly possible but add an extra step to the dags. To avoid unnecessary DAG changes, a generic DAG could be the solutions (as choosen for now to implement).

The permissions operator can cope with both scenario's: (1) a permissions dag or (2) as step for each individual dag.