### PR TITLE
Remove amsterdamseSleutel field from graphql queries

### DIFF
--- a/src/dags/graphql/baggob-ligplaatsen/query.graphql
+++ b/src/dags/graphql/baggob-ligplaatsen/query.graphql
@@ -6,7 +6,6 @@
         cursor
         volgnummer 
         registratiedatum 
-        amsterdamseSleutel 
         geconstateerd 
         status 
         heeftHoofdadres {

--- a/src/dags/graphql/baggob-nummeraanduidingen/query.graphql
+++ b/src/dags/graphql/baggob-nummeraanduidingen/query.graphql
@@ -6,7 +6,6 @@
         cursor
         volgnummer 
         registratiedatum 
-        amsterdamseSleutel 
         huisnummer 
         geconstateerd 
         huisletter 

--- a/src/dags/graphql/baggob-openbareruimtes/query.graphql
+++ b/src/dags/graphql/baggob-openbareruimtes/query.graphql
@@ -6,7 +6,6 @@
         cursor
         volgnummer 
         registratiedatum 
-        amsterdamseSleutel 
         straatcode 
         straatnaamPtt 
         status 

--- a/src/dags/graphql/baggob-panden/query.graphql
+++ b/src/dags/graphql/baggob-panden/query.graphql
@@ -6,7 +6,6 @@
         cursor
         volgnummer 
         registratiedatum 
-        amsterdamseSleutel 
         geconstateerd 
         geometrie 
         oorspronkelijkBouwjaar 

--- a/src/dags/graphql/baggob-standplaatsen/query.graphql
+++ b/src/dags/graphql/baggob-standplaatsen/query.graphql
@@ -6,7 +6,6 @@
         cursor
         volgnummer 
         registratiedatum 
-        amsterdamseSleutel 
         geconstateerd 
         status 
         heeftHoofdadres {

--- a/src/dags/graphql/baggob-verblijfsobjecten/query.graphql
+++ b/src/dags/graphql/baggob-verblijfsobjecten/query.graphql
@@ -6,7 +6,6 @@
         cursor
         volgnummer 
         registratiedatum 
-        amsterdamseSleutel 
         cbsNummer 
         indicatieWoningvoorraad 
         financieringscode 

--- a/src/dags/graphql/baggob-woonplaatsen/query.graphql
+++ b/src/dags/graphql/baggob-woonplaatsen/query.graphql
@@ -6,7 +6,6 @@
         cursor
         volgnummer 
         registratiedatum 
-        amsterdamseSleutel 
         woonplaatsPtt 
         naam 
         geometrie 


### PR DESCRIPTION
GOB has removed this field. It was an old key that
needed to be temporarily available. Now replaced by national bag id.