### PR TITLE
Changed id for processenverbaal_verkiezingen

### DIFF
--- a/src/dags/importscripts/import_processenverbaalverkiezingen.py
+++ b/src/dags/importscripts/import_processenverbaalverkiezingen.py
@@ -1,4 +1,5 @@
 import csv
+from common import make_hash
 from more_ds.network.url import URL
 from typing import List, TypedDict, Iterable
 from swift_hook import SwiftHook
@@ -12,7 +13,7 @@ class Data(TypedDict):
     uri: str
     documentnaam: str
     stemlocatie: str
-    id: str
+    id: int
 
 
 class ObjectStoreListing:
@@ -76,7 +77,7 @@ def save_data(start_folder: str, base_url: str, conn_id: str, output_file: str) 
     data_to_save: List = []
     get_listing = ObjectStoreListing(conn_id)
     for file in get_listing.list_files(start_folder):
-        if 'pdf' in file:
+        if "pdf" in file:
 
             volgnummer = file.split(".")[0]
             documentnaam = file.split(".")[1]
@@ -107,7 +108,7 @@ def save_data(start_folder: str, base_url: str, conn_id: str, output_file: str) 
                 uri=uri,
                 documentnaam=documentnaam,
                 stemlocatie=stemlocatie,
-                id="".join([verkiezingsjaar, volgnummer_split]),
+                id=make_hash([uri], 6),
             )
             data_to_save.append(metadata)
 

--- a/src/dags/sql/processenverbaalverkiezingen.py
+++ b/src/dags/sql/processenverbaalverkiezingen.py
@@ -2,3 +2,15 @@
 SQL_DROP_TMP_TABLE = """
     DROP TABLE IF EXISTS {{ params.tablename }} CASCADE;
 """
+
+# Ogr2ogr demands a numeric-like column as identifier and also makes
+# the datatype default to serial. A serial datatype causes to use
+# a database sequence which has a default output size limit.
+# Any value greater then the limit size, will result in an error.
+# Therefor the temporary identifier is dropped (==fid) and
+# the real identifier is set to be the primairy key after
+# ogr2ogr has loaded the data.
+SQL_REDEFINE_PK = """
+    ALTER TABLE {{ params.tablename }} DROP COLUMN FID;
+    ALTER TABLE {{ params.tablename }} ADD CONSTRAINT {{ params.tablename }}_pkey PRIMARY KEY (ID);
+"""


### PR DESCRIPTION
A hash is used to fill up a id for a verkiezingenprocesverbaal. This prevents possible duplication errors when uploaders are storing pdf's with the same 'volgnummer' and 'jaar'.
Further more, moved the hash function to common since it has been used a couple of times.
