### PR TITLE
AB#6139

### DIFF
--- a/src/plugins/postgres_permissions_operator.py
+++ b/src/plugins/postgres_permissions_operator.py
@@ -38,6 +38,7 @@ DAG_DATASET = {
     "beschermde_": "beschermdestadsdorpsgezichten",
     "hoofdroutes_": "hoofdroutes",
     "reclamebelasting": "belastingen",
+    "processenverbaalverkiezingen": "verkiezingen",
 }
 
 


### PR DESCRIPTION
Processenverbaalverkiezingen was not yet added to the DAG_DATASET dictionary for sets where the DAG_ID is not the same as the schema name. Therefor the grants could not be set properly.