### PR TITLE
Added PostgresPermissionsOperator to individual DAGs for db grants

### DIFF
--- a/src/dags/anpr.py
+++ b/src/dags/anpr.py
@@ -6,6 +6,7 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from http_fetch_operator import HttpFetchOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -111,4 +112,11 @@ with DAG(dag_id, default_args=args, description="aantal geidentificeerde taxiken
         params=dict(base_table=table_id),
     )
 
-(slack_at_start >> mk_tmp_dir >> download_data >> create_temp_table >> import_data >> rename_temp_table)
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
+
+(slack_at_start >> mk_tmp_dir >> download_data >> create_temp_table >> import_data >> rename_temp_table >> grant_db_permissions)

--- a/src/dags/asbest.py
+++ b/src/dags/asbest.py
@@ -95,10 +95,10 @@ with DAG(dag_id, default_args=default_args,) as dag:
         dag_name=dag_id
     )
 
-load_dumps[0] >> rename_col >> rename_tables >> grant_db_permissions
-load_dumps[1] >> rename_tables >> grant_db_permissions
+slack_at_start >> fetch_zip >> extract_zip >> extract_shps
 
 for extract_shp, convert_shp, load_dump in zip(extract_shps, convert_shps, load_dumps):
     extract_shp >> convert_shp >> load_dump
 
-slack_at_start >> fetch_zip >> extract_zip >> extract_shps
+load_dumps[0] >> rename_col >> rename_tables >> grant_db_permissions
+load_dumps[1] >> rename_tables >> grant_db_permissions

--- a/src/dags/bbga.py
+++ b/src/dags/bbga.py
@@ -26,6 +26,7 @@ from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from postgres_insert_csv_operator import FileTable, PostgresInsertCsvOperator
 from postgres_table_copy_operator import PostgresTableCopyOperator
 from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 FileStem = str
 UrlPath = str
@@ -356,6 +357,12 @@ with DAG(dag_id=DAG_ID, default_args=default_args) as dag:
         provide_context=True,  # Ensure we can use XCom to retrieve the previously created tmp dir.
     )
 
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=DAG_ID
+    )
+
     (
         slack_at_start
         >> mk_tmp_dir
@@ -371,4 +378,5 @@ with DAG(dag_id=DAG_ID, default_args=default_args) as dag:
         >> change_data_capture
         >> rm_tmp_tables_post
         >> rm_tmp_dir
+        >> grant_db_permissions
     )

--- a/src/dags/beheerkaart.py
+++ b/src/dags/beheerkaart.py
@@ -7,6 +7,7 @@ from provenance_rename_operator import ProvenanceRenameOperator
 from provenance_drop_from_schema_operator import ProvenanceDropFromSchemaOperator
 from swap_schema_operator import SwapSchemaOperator
 from dcat_swift_operator import DCATSwiftOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -103,5 +104,11 @@ with DAG(
         distribution_id="1",
     )
 
+     # 10. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 # FLOW
-slack_at_start >> drop_tables >> swift_load_task >> provenance_renames >> swap_schema >> mkdir >> create_geopackage >> zip_geopackage >> upload_data  # noqa
+slack_at_start >> drop_tables >> swift_load_task >> provenance_renames >> swap_schema >> mkdir >> create_geopackage >> zip_geopackage >> upload_data >> grant_db_permissions  # noqa

--- a/src/dags/bekendmakingen.py
+++ b/src/dags/bekendmakingen.py
@@ -9,6 +9,7 @@ from http_fetch_operator import HttpFetchOperator
 
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -135,6 +136,12 @@ with DAG(
         new_table_name=f"{dag_id}_{dag_id}",
     )
 
+    # 10. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 (
     slack_at_start
     >> mkdir
@@ -145,6 +152,7 @@ with DAG(
     >> provenance_translation
     >> multi_checks
     >> rename_table
+    >> grant_db_permissions
 )
 
 dag.doc_md = """

--- a/src/dags/beschermde_stadsdorpsgezichten.py
+++ b/src/dags/beschermde_stadsdorpsgezichten.py
@@ -9,6 +9,8 @@ from postgres_check_operator import (
     GEO_CHECK,
 )
 
+from postgres_permissions_operator import PostgresPermissionsOperator
+
 from common import (
     default_args,
     MessageOperator,
@@ -104,6 +106,12 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
 
     rename_table = PostgresOperator(task_id=f"rename_table", sql=RENAME_TABLES_SQL,)
 
+     # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 (
     slack_at_start
     >> drop_imported_table
@@ -111,4 +119,5 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
     >> correct_geo
     >> multi_check
     >> rename_table
+    >> grant_db_permissions
 )

--- a/src/dags/blackspots.py
+++ b/src/dags/blackspots.py
@@ -1,6 +1,7 @@
 from airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from swift_load_sql_operator import SwiftLoadSqlOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -83,4 +84,9 @@ with DAG(dag_id, default_args=default_args,) as dag:
     rename_columns = PostgresOperator(task_id=f"rename_columns", sql=RENAME_COLUMNS,)
     rename_tables = PostgresOperator(task_id="rename_tables", sql=RENAME_TABLES_SQL)
 
-slack_at_start >> drop_tables >> swift_load_task >> rename_columns >> rename_tables
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
+slack_at_start >> drop_tables >> swift_load_task >> rename_columns >> rename_tables >> grant_db_permissions

--- a/src/dags/bouwstroompunten.py
+++ b/src/dags/bouwstroompunten.py
@@ -14,6 +14,7 @@ from environs import Env
 
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -171,6 +172,12 @@ with DAG(
         task_id=f"multi_check", checks=total_checks
     )
 
+     # 11. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 
 (
     slack_at_start
@@ -183,11 +190,12 @@ with DAG(
     >> rename_table
     >> redefine_pk   
     >> multi_checks
+    >> grant_db_permissions
 )
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts power stations data
+    #### DAG summary
+    This DAG contains power stations data
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/cmsa.py
+++ b/src/dags/cmsa.py
@@ -13,6 +13,7 @@ from postgres_files_operator import PostgresFilesOperator
 from swift_operator import SwiftOperator
 
 from provenance_rename_operator import ProvenanceRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -133,6 +134,12 @@ with DAG(
     # 10. Rename temp named tables to final names
     rename_tables = PostgresOperator(task_id="rename_tables", sql=SQL_TABLE_RENAMES)
 
+    # 11. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 
 (
     slack_at_start
@@ -145,12 +152,13 @@ with DAG(
     >> fill_markering
     >> provenance_translation
     >> rename_tables
+    >> grant_db_permissions
 )
 
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts crowd monitoring sensor data,
+    #### DAG summary
+    This DAG contains crowd monitoring sensor data,
     the source is the CMSA (Crowd Monitoring Systeem Amsterdam)
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])

--- a/src/dags/evenementen.py
+++ b/src/dags/evenementen.py
@@ -10,6 +10,7 @@ from airflow.operators.postgres_operator import PostgresOperator
 
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -151,6 +152,12 @@ with DAG(
         new_table_name=f"{dag_id}_{dag_id}",
     )
 
+    # 10. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 
 (
     slack_at_start
@@ -162,11 +169,12 @@ with DAG(
     >> provenance_translation
     >> multi_checks
     >> rename_table
+    >> grant_db_permissions
 )
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts data about leisure events (evenementen)
+    #### DAG summary
+    This DAG contains data about leisure events (evenementen)
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/explosieven.py
+++ b/src/dags/explosieven.py
@@ -9,6 +9,7 @@ from environs import Env
 
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 from swift_operator import SwiftOperator
 
 from common import (
@@ -192,6 +193,13 @@ with DAG(
         for key in files_to_download.keys()
     ]
 
+    # 14. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
+slack_at_start >> mkdir >> download_data 
 
 for data in zip(download_data):
 
@@ -219,11 +227,11 @@ for (
     [multi_check >> drop_table >> rename_table]
 
 
-slack_at_start >> mkdir >> download_data
+rename_tables >> grant_db_permissions
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts explosives related topics
+    #### DAG summary
+    This DAG contains explosives related topics
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/fietspaaltjes.py
+++ b/src/dags/fietspaaltjes.py
@@ -4,6 +4,7 @@ from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from http_fetch_operator import HttpFetchOperator
 from postgres_files_operator import PostgresFilesOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -56,4 +57,10 @@ with DAG(dag_id, default_args=default_args, template_searchpath=["/"]) as dag:
         params=dict(tablename=f"{dag_id}_{dag_id}", pk="pkey"),
     )
 
-slack_at_start >> fetch_json >> create_sql >> create_and_fill_table >> rename_table
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
+slack_at_start >> fetch_json >> create_sql >> create_and_fill_table >> rename_table >> grant_db_permissions

--- a/src/dags/gob.py
+++ b/src/dags/gob.py
@@ -8,6 +8,7 @@ from dynamic_dagrun_operator import TriggerDynamicDagRunOperator
 from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
 from postgres_table_init_operator import PostgresTableInitOperator
 from postgres_table_copy_operator import PostgresTableCopyOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 from http_gob_operator import HttpGobOperator
 from common import (
     default_args,
@@ -153,6 +154,12 @@ def create_gob_dag(is_first: bool, gob_dataset_id: str, gob_table_id: str) -> DA
             trigger_rule="all_done",
         )
 
+        # 9. Grant database permissions
+        grant_db_permissions = PostgresPermissionsOperator(
+            task_id="grants",
+            dag_name=dag_id
+        )
+
         # FLOW
         (
             slack_at_start
@@ -162,6 +169,7 @@ def create_gob_dag(is_first: bool, gob_dataset_id: str, gob_table_id: str) -> DA
             >> copy_table
             >> create_extra_index
             >> trigger_next_dag
+            >> grant_db_permissions
         )
 
     return dag

--- a/src/dags/grex.py
+++ b/src/dags/grex.py
@@ -14,6 +14,7 @@ from common import default_args
 from common.sql import SQL_CHECK_COUNT, SQL_CHECK_GEO
 from common.db import get_engine, get_ora_engine
 from postgres_check_operator import PostgresCheckOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 dag_id = "grex"
 
@@ -124,5 +125,11 @@ with DAG(
 
     rename_table = PostgresOperator(task_id="rename_table", sql=SQL_TABLE_RENAME)
 
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
 
-load_data >> check_count >> check_geo >> rename_table
+
+load_data >> check_count >> check_geo >> rename_table >> grant_db_permissions

--- a/src/dags/hior.py
+++ b/src/dags/hior.py
@@ -4,6 +4,7 @@ from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     pg_params,
@@ -102,6 +103,13 @@ with DAG(dag_id, default_args=default_args, template_searchpath=["/"]) as dag:
 
     rename_table = PostgresOperator(task_id="rename_table", sql=SQL_TABLE_RENAME)
 
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
+
 (
     slack_at_start
     >> fetch_xls
@@ -109,6 +117,7 @@ with DAG(dag_id, default_args=default_args, template_searchpath=["/"]) as dag:
     >> create_table
     >> import_tables[1:]
     >> rename_table
+    >> grant_db_permissions
 )
 
 create_table >> import_tables[0] >> import_linked_tables >> rename_table

--- a/src/dags/hoofdroutes.py
+++ b/src/dags/hoofdroutes.py
@@ -14,6 +14,7 @@ from common.sql import (
 )
 from importscripts.import_hoofdroutes import import_hoofdroutes
 from postgres_check_operator import PostgresCheckOperator, PostgresValueCheckOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 
 dag_id = "hoofdroutes"
@@ -65,8 +66,14 @@ with DAG(dag_id, default_args=default_args,) as dag:
         task_id="rename_table", sql=SQL_TABLE_RENAME, params=dict(tablename=dag_id),
     )
 
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 import_routes >> extract_geojson >> load_table >> [
     check_count,
     check_geo,
     check_colnames,
-] >> rename_table
+] >> rename_table >> grant_db_permissions

--- a/src/dags/hoofdroutes_verkeer.py
+++ b/src/dags/hoofdroutes_verkeer.py
@@ -19,6 +19,7 @@ from postgres_check_operator import (
     GEO_CHECK,
 )
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 from schematools.importer.geojson import GeoJSONImporter
 from schematools.introspect.geojson import introspect_geojson_files
 from schematools.types import DatasetSchema
@@ -211,5 +212,11 @@ with DAG(dag_id, default_args=default_args) as dag:
         for route in ROUTES
     ]
 
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
 
-drop_old_tables >> import_geojson >> multi_check >> renames
+
+drop_old_tables >> import_geojson >> multi_check >> renames >> grant_db_permissions

--- a/src/dags/horeca_exploitatievergunning.py
+++ b/src/dags/horeca_exploitatievergunning.py
@@ -13,6 +13,7 @@ from common import default_args
 from common.sql import SQL_CHECK_COUNT, SQL_CHECK_GEO
 from common.db import get_engine, get_ora_engine
 from postgres_check_operator import PostgresCheckOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 dag_id = "horeca_exploitatievergunning"
 
@@ -189,4 +190,10 @@ with DAG(
 
     rename_table = PostgresOperator(task_id="rename_table", sql=SQL_TABLE_RENAME)
 
-load_data >> check_count >> check_geo1 >> check_geo2 >> rename_table
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
+load_data >> check_count >> check_geo1 >> check_geo2 >> rename_table >> grant_db_permissions

--- a/src/dags/milieuzones.py
+++ b/src/dags/milieuzones.py
@@ -8,6 +8,7 @@ from airflow.operators.dummy_operator import DummyOperator
 
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 from swift_operator import SwiftOperator
 
 from common import (
@@ -184,6 +185,14 @@ with DAG(
         for key in tables_to_create.keys()
     ]
 
+    # 11. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
+slack_at_start >> mkdir >> download_data
+
 for data, convert in zip(download_data, convert_to_geojson):
 
     data >> convert >> Interface >> SHP_to_SQL
@@ -202,11 +211,11 @@ for (
 
     [revalidate_geometry_record >> multi_check >> rename_table]
 
-slack_at_start >> mkdir >> download_data
+rename_tables >> grant_db_permissions
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts data about environmental omission zones (milieuzones) i.e. touringcars, taxi's, brom- en snorfietsen, vrachtwagens en bestelbussen.
+    #### DAG summary
+    This DAG contains data about environmental omission zones (milieuzones) i.e. touringcars, taxi's, brom- en snorfietsen, vrachtwagens en bestelbussen.
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/parkeervakken.py
+++ b/src/dags/parkeervakken.py
@@ -19,6 +19,7 @@ from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
 )
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 
 dag_id = "parkeervakken"
@@ -306,6 +307,12 @@ with DAG(
         params=dict(base_table=f"{dag_id}_{dag_id}"),
     )
 
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 (
     mk_tmp_dir
     >> download_and_extract_zip
@@ -314,6 +321,7 @@ with DAG(
     >> run_import_task
     >> count_check
     >> rename_temp_tables
+    >> grant_db_permissions
 )
 
 

--- a/src/dags/processenverbaal_verkiezingen.py
+++ b/src/dags/processenverbaal_verkiezingen.py
@@ -8,6 +8,7 @@ from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from ogr2ogr_operator import Ogr2OgrOperator
 from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -147,6 +148,12 @@ with DAG(
         params=dict(tablename=f"{schema_name}_{table_name}_new"),
     )
 
+    # 12. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 # FLOW
 (
     slack_at_start
@@ -159,11 +166,12 @@ with DAG(
     >> create_target_table
     >> change_data_capture
     >> clean_up
+    >> grant_db_permissions
 )
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts URI's (and metadata) of 'processenverbaal verkiezingen'
+    #### DAG summary
+    This DAG contains URI's (and metadata) of 'processenverbaal verkiezingen'
     document publications. This DAG supposed to run for a short period after
     the elections. When all documents (processenverbaal) have been uploaded to
     the objectstore, this dag can be set inactive. When active, it wil run

--- a/src/dags/reclamebelasting.py
+++ b/src/dags/reclamebelasting.py
@@ -9,6 +9,7 @@ from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from ogr2ogr_operator import Ogr2OgrOperator
 from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -169,6 +170,12 @@ with DAG(
         params=dict(tablename=f"{schema_name}_{table_name}_new"),
     )
 
+    # 11. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 # FLOW
 (
     slack_at_start
@@ -181,11 +188,12 @@ with DAG(
     >> create_table
     >> change_data_capture
     >> clean_up
+    >> grant_db_permissions
 )
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts advertising tax areas and rates.
+    #### DAG summary
+    This DAG contains advertising tax areas and rates.
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/rioolnetwerk.py
+++ b/src/dags/rioolnetwerk.py
@@ -3,6 +3,7 @@ from airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from swift_load_sql_operator import SwiftLoadSqlOperator
 from provenance_rename_operator import ProvenanceRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -131,6 +132,21 @@ with DAG(dag_id,
     )
 
     rename_tables = PostgresOperator(task_id="rename_tables", sql=RENAME_TABLES_SQL,)
+    
+    # Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
 
 
-slack_at_start >> drop_tables >> swift_load_task >> multi_check >> rename_columns >> rename_tables
+[
+    slack_at_start 
+    >> drop_tables 
+    >> swift_load_task 
+    >> multi_check 
+    >> rename_columns 
+    >> rename_tables 
+    >> grant_db_permissions
+]
+

--- a/src/dags/spoorlijnen.py
+++ b/src/dags/spoorlijnen.py
@@ -7,6 +7,7 @@ from airflow.operators.postgres_operator import PostgresOperator
 
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 from swift_operator import SwiftOperator
 
 from common import (
@@ -173,6 +174,13 @@ with DAG(
         for key in files_to_download.keys()
     ]
 
+    # 11. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
+slack_at_start >> mkdir >> download_data
 
 for data in zip(download_data):
 
@@ -195,11 +203,11 @@ for (
     [multi_check >> rename_table]
 
 
-slack_at_start >> mkdir >> download_data
+rename_tables >> grant_db_permissions
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts data about railtracks metro and tram
+    #### DAG summary
+    This DAG contains data about railtracks metro and tram
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/varen.py
+++ b/src/dags/varen.py
@@ -3,6 +3,7 @@ from swift_load_sql_operator import SwiftLoadSqlOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from provenance_drop_from_schema_operator import ProvenanceDropFromSchemaOperator
 from swap_schema_operator import SwapSchemaOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -58,6 +59,12 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
     # 5. Swap tables to target schema public
     swap_schema = SwapSchemaOperator(task_id="swap_schema", dataset_name="varen")
 
+    # 6. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 # FLOW
 
-slack_at_start >> drop_tables >> swift_load_task >> provenance_renames >> swap_schema
+slack_at_start >> drop_tables >> swift_load_task >> provenance_renames >> swap_schema >> grant_db_permissions

--- a/src/dags/vastgoed.py
+++ b/src/dags/vastgoed.py
@@ -5,6 +5,7 @@ from airflow.operators.bash_operator import BashOperator
 
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 from swift_operator import SwiftOperator
 
 from common import (
@@ -122,13 +123,31 @@ with DAG(
             task_id=f"rename_table_{dag_id}",
             old_table_name=f"{dag_id}_{dag_id}_new",
             new_table_name=f"{dag_id}_{dag_id}",
-        )    
+        )
+    
+    # 10. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
 
-slack_at_start >> mkdir >> download_data >> convert_to_UTF8 >> CSV_to_SQL >> insert_data >> provenance_translation >> multi_checks >> rename_tables
+[
+    slack_at_start 
+    >> mkdir 
+    >> download_data 
+    >> convert_to_UTF8 
+    >> CSV_to_SQL 
+    >> insert_data 
+    >> provenance_translation 
+    >> multi_checks 
+    >> rename_tables 
+    >> grant_db_permissions
+]
+
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts data of real estate objects of the city of Amsterdam
+    #### DAG summary
+    This DAG contains data of real estate objects of the city of Amsterdam
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/verzinkbarepalen.py
+++ b/src/dags/verzinkbarepalen.py
@@ -7,6 +7,7 @@ from airflow import DAG
 from ogr2ogr_operator import Ogr2OgrOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from airflow.operators.bash_operator import BashOperator
 from http_fetch_operator import HttpFetchOperator
@@ -131,6 +132,12 @@ with DAG(
         new_table_name=f"{dag_id}_{dag_id}",
     )
 
+    # 9. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 
 (
     slack_at_start
@@ -141,12 +148,13 @@ with DAG(
     >> provenance_translation
     >> multi_checks
     >> rename_table
+    >> grant_db_permissions
 )
 
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts data about retractable posts and other closing mechanisms
+    #### DAG summary
+    This DAG contains data about retractable posts and other closing mechanisms
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/winkelgebieden.py
+++ b/src/dags/winkelgebieden.py
@@ -8,6 +8,7 @@ from airflow.operators.postgres_operator import PostgresOperator
 
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 
 from common import (
@@ -141,6 +142,12 @@ with DAG(
         task_id="multi_check", checks=total_checks
     )
 
+    # 11. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 (
     slack_at_start
     >> mkdir
@@ -152,11 +159,12 @@ with DAG(
     >> rename_table
     >> add_category
     >> multi_checks
+    >> grant_db_permissions
 )
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts shopping area's (winkelgebieden)
+    #### DAG summary
+    This DAG contains shopping area's (winkelgebieden)
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/wior.py
+++ b/src/dags/wior.py
@@ -15,6 +15,7 @@ from ogr2ogr_operator import Ogr2OgrOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from more_ds.network.url import URL
 
@@ -213,6 +214,12 @@ with DAG(
         params=dict(tablename=f"{dag_id}_{dag_id}_new"),
     )
 
+    # 13. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 (
     slack_at_start
     >> mkdir
@@ -227,11 +234,12 @@ with DAG(
     >> create_table
     >> change_data_capture
     >> clean_up
+    >> grant_db_permissions
 )
 
 dag.doc_md = """
-    #### DAG summery
-    This DAG containts public construction sites / projects
+    #### DAG summary
+    This DAG contains public construction sites / projects
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/woningbouwplannen.py
+++ b/src/dags/woningbouwplannen.py
@@ -4,6 +4,7 @@ from swift_load_sql_operator import SwiftLoadSqlOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from provenance_drop_from_schema_operator import ProvenanceDropFromSchemaOperator
 from swap_schema_operator import SwapSchemaOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
 
 from common import (
     default_args,
@@ -98,6 +99,12 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
     # 6. Extra manual renaming for the nm-tables
     nm_tables_rename = PostgresOperator(task_id="nm_tables_rename", sql=NM_RENAMES_SQL,)
 
+    # 7. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(
+        task_id="grants",
+        dag_name=dag_id
+    )
+
 # FLOW
 (
     slack_at_start
@@ -106,4 +113,5 @@ with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
     >> provenance_renames
     >> swap_schema
     >> nm_tables_rename
+    >> grant_db_permissions
 )

--- a/src/plugins/postgres_permissions_operator.py
+++ b/src/plugins/postgres_permissions_operator.py
@@ -185,6 +185,14 @@ class PostgresPermissionsOperator(BaseOperator):
         # Option TWO: grant on single dataset (can be used as a final step within a dag run)
         elif self.dataset_name and not self.batch_ind:
 
+            # get real datasetname from DAG_DATASET constant, if dag_id != dataschema name
+            for key in DAG_DATASET.keys():
+                if key in self.dataset_name:
+                    self.dataset_name = DAG_DATASET[key]
+                    break
+
+            logger.info("set grants for %s", self.dataset_name)
+
             try:
                 ams_schema = schema_defs_from_url(
                     schemas_url=self.schema_url, dataset_name=self.dataset_name


### PR DESCRIPTION
I added the PostgresPermissionsOperator as a last task to almost every DAG. This is to substitute the `airflow_db_permissions` DAG (which runs every 15 minutes now). 