### PR TITLE
Jan/fix dag connection warnings

### DIFF
--- a/src/dags/aardgasvrijezones.py
+++ b/src/dags/aardgasvrijezones.py
@@ -169,7 +169,9 @@ slack_at_start >> mkdir >> download_data
 
 for data in zip(download_data):
 
-    data >> Interface >> SHP_to_SQL
+    data >> Interface
+
+Interface >> SHP_to_SQL
 
 for (create_SQL, create_table, multi_check, rename_table,) in zip(
     SHP_to_SQL,
@@ -178,9 +180,11 @@ for (create_SQL, create_table, multi_check, rename_table,) in zip(
     rename_tables,
 ):
 
-    [create_SQL >> create_table] >> provenance_translation >> multi_checks
+    [create_SQL >> create_table] >> provenance_translation
 
     [multi_check >> rename_table]
+
+provenance_translation >> multi_checks
 
 rename_tables >> grant_db_permissions
 

--- a/src/dags/aardgasvrijezones.py
+++ b/src/dags/aardgasvrijezones.py
@@ -147,9 +147,7 @@ with DAG(
 
     # 8. Execute bundled checks on database
     multi_checks = [
-        PostgresMultiCheckOperator(
-            task_id=f"multi_check_{key}", checks=check_name[f"{key}"]
-        )
+        PostgresMultiCheckOperator(task_id=f"multi_check_{key}", checks=check_name[f"{key}"])
         for key in files_to_download.keys()
     ]
 
@@ -164,10 +162,7 @@ with DAG(
     ]
 
     # 10. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 
 slack_at_start >> mkdir >> download_data
@@ -177,7 +172,10 @@ for data in zip(download_data):
     data >> Interface >> SHP_to_SQL
 
 for (create_SQL, create_table, multi_check, rename_table,) in zip(
-    SHP_to_SQL, create_tables, multi_checks, rename_tables,
+    SHP_to_SQL,
+    create_tables,
+    multi_checks,
+    rename_tables,
 ):
 
     [create_SQL >> create_table] >> provenance_translation >> multi_checks
@@ -188,7 +186,7 @@ rename_tables >> grant_db_permissions
 
 dag.doc_md = """
     #### DAG summary
-    This DAG contains data of natural gas free districts (aardgasvrije buurten) and local initiatives 
+    This DAG contains data of natural gas free districts (aardgasvrije buurten) and local initiatives
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions
@@ -200,7 +198,7 @@ dag.doc_md = """
     #### Prerequisites/Dependencies/Resourcing
     https://api.data.amsterdam.nl/v1/docs/datasets/aardgasvrijezones.html
     https://api.data.amsterdam.nl/v1/docs/wfs-datasets/aardgasvrijezones.html
-    Example geosearch: 
+    Example geosearch:
     https://api.data.amsterdam.nl/geosearch?datasets=aardgasvrijezones/buurt&x=106434&y=488995&radius=10
     https://api.data.amsterdam.nl/geosearch?datasets=aardgasvrijezones/buurtinitiatief&x=106434&y=488995&radius=10
 """

--- a/src/dags/bedrijveninvesteringszone.py
+++ b/src/dags/bedrijveninvesteringszone.py
@@ -90,8 +90,7 @@ with DAG(
     SHP_to_SQL = [
         BashOperator(
             task_id="SHP_to_SQL",
-            bash_command=f"ogr2ogr -f 'PGDump' "
-            f"{tmp_dir}/{dag_id}.sql {tmp_dir}/{file}",
+            bash_command=f"ogr2ogr -f 'PGDump' " f"{tmp_dir}/{dag_id}.sql {tmp_dir}/{file}",
         )
         for files in files_to_download.values()
         for file in files
@@ -165,7 +164,10 @@ with DAG(
     geo_checks.append(
         GEO_CHECK.make_check(
             check_id=f"geo_check",
-            params=dict(table_name=f"{dag_id}_{dag_id}_new", geotype=["POLYGON"],),
+            params=dict(
+                table_name=f"{dag_id}_{dag_id}_new",
+                geotype=["POLYGON"],
+            ),
             pass_value=1,
         )
     )
@@ -173,9 +175,7 @@ with DAG(
     total_checks = count_checks + geo_checks
 
     # 12. RUN bundled CHECKS
-    multi_checks = PostgresMultiCheckOperator(
-        task_id="multi_check", checks=total_checks
-    )
+    multi_checks = PostgresMultiCheckOperator(task_id="multi_check", checks=total_checks)
 
     # 13. Rename TABLE
     rename_table = PostgresTableRenameOperator(
@@ -185,10 +185,7 @@ with DAG(
     )
 
     # 14. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 
 slack_at_start >> mkdir >> download_data
@@ -197,16 +194,16 @@ for data in download_data:
     data >> Interface
 
 (
-    Interface 
-    >> SHP_to_SQL 
-    >> SQL_convert_UTF8 
-    >> SQL_update_data 
-    >> create_table 
-    >> import_data 
-    >> update_table 
-    >> provenance_translation 
-    >> multi_checks 
-    >> rename_table 
+    Interface
+    >> SHP_to_SQL
+    >> SQL_convert_UTF8
+    >> SQL_update_data
+    >> create_table
+    >> import_data
+    >> update_table
+    >> provenance_translation
+    >> multi_checks
+    >> rename_table
     >> grant_db_permissions
 )
 
@@ -222,9 +219,9 @@ dag.doc_md = """
     https://data.amsterdam.nl/datasets/bl6Wf85K8CfnwA/bedrijfsinvesteringszones-biz/
     #### Business Use Case / process / origin
     Na
-    #### Prerequisites/Dependencies/Resourcing  
+    #### Prerequisites/Dependencies/Resourcing
     https://api.data.amsterdam.nl/v1/docs/datasets/bedrijveninvesteringszones.html
     https://api.data.amsterdam.nl/v1/docs/wfs-datasets/bedrijveninvesteringszones.html
-    Example geosearch: 
+    Example geosearch:
     https://api.data.amsterdam.nl/geosearch?datasets=bedrijveninvesteringszones/bedrijveninvesteringszones&x=106434&y=488995&radius=10
 """

--- a/src/dags/bodem.py
+++ b/src/dags/bodem.py
@@ -209,9 +209,14 @@ for (
 
     [
         data >> change_seperator >> create_SQL >> create_table >> redefine_geom
-    ] >> provenance_translation >> multi_check
+    ] >> provenance_translation
 
-    [multi_check >> drop_table >> rename_table] >> grant_db_permissions
+    [multi_check >> drop_table >> rename_table]
+
+
+provenance_translation >> multi_checks
+
+rename_tables >> grant_db_permissions
 
 (slack_at_start >> mkdir >> download_data)
 

--- a/src/dags/bodem.py
+++ b/src/dags/bodem.py
@@ -131,7 +131,9 @@ with DAG(
     drop_tables = [
         PostgresOperator(
             task_id=f"drop_existing_table_{key}",
-            sql=[f"DROP TABLE IF EXISTS {dag_id}_{key} CASCADE",],
+            sql=[
+                f"DROP TABLE IF EXISTS {dag_id}_{key} CASCADE",
+            ],
         )
         for key in files_to_download.keys()
     ]
@@ -165,7 +167,10 @@ with DAG(
         geo_checks.append(
             GEO_CHECK.make_check(
                 check_id=f"geo_check_{key}",
-                params=dict(table_name=f"{key}", geotype=["POINT"],),
+                params=dict(
+                    table_name=f"{key}",
+                    geotype=["POINT"],
+                ),
                 pass_value=1,
             )
         )
@@ -175,17 +180,12 @@ with DAG(
 
     # 11. Execute bundled checks on database
     multi_checks = [
-        PostgresMultiCheckOperator(
-            task_id=f"multi_check_{key}", checks=check_name[f"{key}"]
-        )
+        PostgresMultiCheckOperator(task_id=f"multi_check_{key}", checks=check_name[f"{key}"])
         for key in files_to_download.keys()
     ]
 
-     # 12. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    # 12. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 for (
     data,

--- a/src/dags/covid_19.py
+++ b/src/dags/covid_19.py
@@ -175,7 +175,9 @@ slack_at_start >> mkdir >> download_data
 
 for data in zip(download_data):
 
-    data >> Interface >> SHP_to_SQL
+    data >> Interface
+
+Interface >> SHP_to_SQL
 
 for (create_SQL, create_table, rename_table,) in zip(
     SHP_to_SQL,
@@ -183,9 +185,11 @@ for (create_SQL, create_table, rename_table,) in zip(
     rename_tables,
 ):
 
-    [
-        create_SQL >> create_table
-    ] >> provenance_translation >> multi_checks >> Interface2 >> rename_table
+    [create_SQL >> create_table] >> provenance_translation
+
+provenance_translation >> multi_checks >> Interface2
+
+Interface2 >> rename_tables
 
 rename_tables >> grant_db_permissions
 

--- a/src/dags/deelmobiliteit.py
+++ b/src/dags/deelmobiliteit.py
@@ -255,7 +255,9 @@ Interface2 >> set_geom
 
 for (set_geom, multi_checks) in zip(set_geom, multi_checks):
 
-    [set_geom >> multi_checks] >> provenance >> change_data_capture  # type: ignore
+    [set_geom >> multi_checks] >> provenance
+
+provenance >> change_data_capture  # type: ignore
 
 for (change_data_capture, clean_up, history_window) in zip(
     change_data_capture, clean_up, history_window

--- a/src/dags/explosieven.py
+++ b/src/dags/explosieven.py
@@ -203,7 +203,9 @@ slack_at_start >> mkdir >> download_data
 
 for data in zip(download_data):
 
-    data >> Interface >> SHP_to_SQL
+    data >> Interface
+
+Interface >> SHP_to_SQL
 
 for (create_SQL, create_table, remove_col, multi_check, drop_table, rename_table,) in zip(
     SHP_to_SQL,
@@ -214,14 +216,11 @@ for (create_SQL, create_table, remove_col, multi_check, drop_table, rename_table
     rename_tables,
 ):
 
-    [create_SQL >> create_table >> remove_col] >> provenance_translation >> add_hyperlink_pdf
-
-    for hyperlink in zip(add_hyperlink_pdf):
-
-        hyperlink >> Interface2 >> multi_check
+    [create_SQL >> create_table >> remove_col] >> provenance_translation
 
     [multi_check >> drop_table >> rename_table]
 
+provenance_translation >> add_hyperlink_pdf >> Interface2 >> multi_checks
 
 rename_tables >> grant_db_permissions
 

--- a/src/dags/geluidzones.py
+++ b/src/dags/geluidzones.py
@@ -242,11 +242,15 @@ slack_at_start >> mkdir >> download_data
 
 for (data, change_seperator) in zip(download_data, change_seperators):
 
-    [data >> change_seperator] >> Interface >> csv_to_SQL
+    [data >> change_seperator] >> Interface
+
+Interface >> csv_to_SQL
 
 for create_SQL, create_table in zip(csv_to_SQL, create_tables):
 
-    [create_SQL >> create_table] >> provenance_translation >> redefine_geoms
+    [create_SQL >> create_table] >> provenance_translation
+
+provenance_translation >> redefine_geoms
 
 for (
     redefine_geom,
@@ -255,7 +259,9 @@ for (
     rename_table,
 ) in zip(redefine_geoms, add_thema_contexts, multi_checks, rename_tables):
 
-    [redefine_geom >> add_thema_context >> multi_check >> rename_table] >> Interface2 >> drop_cols
+    [redefine_geom >> add_thema_context >> multi_check >> rename_table] >> Interface2
+
+Interface2 >> drop_cols
 
 for drop_col in zip(drop_cols):
     drop_col >> drop_parent_table

--- a/src/dags/milieuzones.py
+++ b/src/dags/milieuzones.py
@@ -203,10 +203,7 @@ with DAG(
     ]
 
     # 11. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 slack_at_start >> mkdir >> download_data
 

--- a/src/dags/milieuzones.py
+++ b/src/dags/milieuzones.py
@@ -209,7 +209,9 @@ slack_at_start >> mkdir >> download_data
 
 for data, convert in zip(download_data, convert_to_geojson):
 
-    data >> convert >> Interface >> import_data
+    data >> convert >> Interface
+
+Interface >> import_data
 
 for (
     import_data_file,

--- a/src/dags/ondergrond.py
+++ b/src/dags/ondergrond.py
@@ -218,17 +218,12 @@ with DAG(
     ]
 
     # 13. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 slack_at_start >> mkdir >> download_data
 
 # FLOW
-for (download_file, create_table, import_data) in zip(
-    download_data, create_tables, GEOJSON_to_DB
-):
+for (download_file, create_table, import_data) in zip(download_data, create_tables, GEOJSON_to_DB):
 
     [download_file >> create_table >> import_data] >> provenance_translation >> multi_checks
 

--- a/src/dags/openbareverlichting.py
+++ b/src/dags/openbareverlichting.py
@@ -128,7 +128,10 @@ with DAG(
     geo_checks.append(
         GEO_CHECK.make_check(
             check_id=f"geo_check",
-            params=dict(table_name=f"{dag_id}_{dag_id}_new", geotype=["POINT"],),
+            params=dict(
+                table_name=f"{dag_id}_{dag_id}_new",
+                geotype=["POINT"],
+            ),
             pass_value=1,
         )
     )
@@ -136,9 +139,7 @@ with DAG(
     total_checks = count_checks + geo_checks
 
     # 8. RUN bundled CHECKS
-    multi_checks = PostgresMultiCheckOperator(
-        task_id=f"multi_check", checks=total_checks
-    )
+    multi_checks = PostgresMultiCheckOperator(task_id=f"multi_check", checks=total_checks)
     # 9. Rename table
     rename_table = PostgresTableRenameOperator(
         task_id="rename_table",
@@ -147,10 +148,7 @@ with DAG(
     )
 
     # 10. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 slack_at_start >> mkdir >> download_data
 
@@ -174,7 +172,7 @@ dag.doc_md = """
     #### Prerequisites/Dependencies/Resourcing
     https://api.data.amsterdam.nl/v1/docs/datasets/openbare_verlichting.html
     https://api.data.amsterdam.nl/v1/docs/wfs-datasets/openbare_verlichting.html
-    Example geosearch: 
+    Example geosearch:
     https://api.data.amsterdam.nl/geosearch?datasets=openbare_verlichting/openbare_verlichting&x=111153&y=483288&radius=10
     https://api.data.amsterdam.nl/geosearch?datasets=openbare_verlichting/openbare_verlichting&x=111153&y=483288&radius=10
 """

--- a/src/dags/openbareverlichting.py
+++ b/src/dags/openbareverlichting.py
@@ -152,11 +152,18 @@ with DAG(
 
 slack_at_start >> mkdir >> download_data
 
-for data in zip(download_data):
+# for data in zip(download_data):
 
-    data >> convert_to_geojson >> geojson_to_SQL >> create_table >> provenance_translation >> multi_checks >> rename_table
-
-rename_table >> grant_db_permissions
+(
+    download_data
+    >> convert_to_geojson
+    >> geojson_to_SQL
+    >> create_table
+    >> provenance_translation
+    >> multi_checks
+    >> rename_table
+    >> grant_db_permissions
+)
 
 dag.doc_md = """
     #### DAG summary

--- a/src/dags/overlastgebieden.py
+++ b/src/dags/overlastgebieden.py
@@ -186,7 +186,9 @@ slack_at_start >> mkdir >> download_data
 
 for data in zip(download_data):
 
-    data >> Interface >> SHP_to_SQL
+    data >> Interface
+
+Interface >> SHP_to_SQL
 
 for (create_SQL, create_table, remove_null_geometry_record,) in zip(
     SHP_to_SQL,
@@ -194,9 +196,9 @@ for (create_SQL, create_table, remove_null_geometry_record,) in zip(
     remove_null_geometry_records,
 ):
 
-    [
-        create_SQL >> create_table >> remove_null_geometry_record
-    ] >> provenance_translation >> multi_checks >> Interface2 >> rename_tables
+    [create_SQL >> create_table >> remove_null_geometry_record] >> provenance_translation
+
+provenance_translation >> multi_checks >> Interface2 >> rename_tables
 
 rename_tables >> grant_db_permissions
 

--- a/src/dags/overlastgebieden.py
+++ b/src/dags/overlastgebieden.py
@@ -31,7 +31,7 @@ variables_overlastgebieden = Variable.get("overlastgebieden", deserialize_json=T
 files_to_download = variables_overlastgebieden["files_to_download"]
 tables_to_create = variables_overlastgebieden["tables_to_create"]
 # Note: Vuurwerkvrijezones (VVZ) data is temporaly! not processed due to covid19 national measures
-tables_to_check = { k:v for k, v in tables_to_create.items() if k != 'vuurwerkvrij' }
+tables_to_check = {k: v for k, v in tables_to_create.items() if k != "vuurwerkvrij"}
 tmp_dir = f"{SHARED_DIR}/{dag_id}"
 total_checks = []
 count_checks = []
@@ -149,7 +149,8 @@ with DAG(
             GEO_CHECK.make_check(
                 check_id=f"geo_check_{key}",
                 params=dict(
-                    table_name=f"{dag_id}_{key}_new", geotype=["MULTIPOLYGON"],
+                    table_name=f"{dag_id}_{key}_new",
+                    geotype=["MULTIPOLYGON"],
                 ),
                 pass_value=1,
             )
@@ -160,9 +161,7 @@ with DAG(
 
     # 9. Execute bundled checks on database
     multi_checks = [
-        PostgresMultiCheckOperator(
-            task_id=f"multi_check_{key}", checks=check_name[f"{key}"]
-        )
+        PostgresMultiCheckOperator(task_id=f"multi_check_{key}", checks=check_name[f"{key}"])
         for key in tables_to_check.keys()
     ]
 
@@ -181,10 +180,7 @@ with DAG(
     ]
 
     # 12. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 slack_at_start >> mkdir >> download_data
 
@@ -192,11 +188,7 @@ for data in zip(download_data):
 
     data >> Interface >> SHP_to_SQL
 
-for (
-    create_SQL,
-    create_table,
-    remove_null_geometry_record,
-) in zip(
+for (create_SQL, create_table, remove_null_geometry_record,) in zip(
     SHP_to_SQL,
     create_tables,
     remove_null_geometry_records,

--- a/src/dags/precariobelasting.py
+++ b/src/dags/precariobelasting.py
@@ -244,9 +244,12 @@ with DAG(
 
         [
             data >> clean_data >> extract_geojson >> load_table >> multi_check
-        ] >> provenance_translation >> drop_table
+        ] >> provenance_translation
 
-        [drop_table >> rename_table >> add_title_column] >> Interface >> add_gebied_columns
+        [drop_table >> rename_table >> add_title_column] >> Interface
+
+    provenance_translation >> drop_tables
+    Interface >> add_gebied_columns
 
     for add_gebied_column, rename_value_gebied in zip(add_gebied_columns, rename_value_gebieden):
         add_gebied_column >> rename_value_gebied

--- a/src/dags/rdw.py
+++ b/src/dags/rdw.py
@@ -136,9 +136,9 @@ slack_at_start >> mkdir >> download_data
 
 for (get_data, load_data) in zip(download_data, import_data):
 
-    [
-        get_data >> load_data
-    ] >> create_tmp_table >> provenance >> swap_table >> clean_up_files >> grant_db_permissions
+    [get_data >> load_data] >> create_tmp_table
+
+create_tmp_table >> provenance >> swap_table >> clean_up_files >> grant_db_permissions
 
 
 dag.doc_md = """

--- a/src/dags/risicozones.py
+++ b/src/dags/risicozones.py
@@ -307,10 +307,7 @@ with DAG(
     ]
 
     # 21. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 
 # FLOW. define flow with parallel executing of serial tasks for each file

--- a/src/dags/risicozones.py
+++ b/src/dags/risicozones.py
@@ -315,31 +315,41 @@ slack_at_start >> mk_tmp_dir >> download_data
 
 for download in zip(download_data):
 
-    download >> Interface >> merge_data
+    download >> Interface
+
+Interface >> merge_data
 
 for merge_data in zip(merge_data):
 
-    merge_data >> Interface2 >> union_data
+    merge_data >> Interface2
+
+Interface2 >> union_data
 
 for stack_data in zip(union_data):
 
-    stack_data >> Interface3 >> cleanse_data
+    stack_data >> Interface3
+
+Interface3 >> cleanse_data
 
 for cleanse_file in zip(cleanse_data):
 
-    cleanse_file >> Interface4 >> fix_geometry
+    cleanse_file >> Interface4
+
+Interface4 >> fix_geometry
 
 for fix_geom in zip(fix_geometry):
 
-    fix_geom >> Interface5 >> change_seperator
+    fix_geom >> Interface5
+
+Interface5 >> change_seperator
 
 for change_seperator, to_sql, set_geom, create_table in zip(
     change_seperator, to_sql, redefine_geoms, create_tables
 ):
 
-    [
-        change_seperator >> to_sql >> set_geom >> create_table
-    ] >> provenance_translation >> multi_checks
+    [change_seperator >> to_sql >> set_geom >> create_table] >> provenance_translation
+
+provenance_translation >> multi_checks
 
 for data_check, detect_changes, del_tmp_table in zip(multi_checks, change_data_capture, clean_up):
 

--- a/src/dags/schiphol.py
+++ b/src/dags/schiphol.py
@@ -238,11 +238,15 @@ slack_at_start >> mk_tmp_dir >> download_data
 
 for (download, change_seperator, import_data) in zip(download_data, change_seperator, to_sql):
 
-    [download >> change_seperator >> import_data] >> Interface >> add_thema_contexts
+    [download >> change_seperator >> import_data] >> Interface
+
+Interface >> add_thema_contexts
 
 for add_thema_context in zip(add_thema_contexts):
 
-    add_thema_context >> provenance_translation >> drop_cols
+    add_thema_context >> provenance_translation
+
+provenance_translation >> drop_cols
 
 for (drop_column, set_geom, multi_check, create_table, change_data_capture, clean_up) in zip(
     drop_cols, redefine_geoms, multi_checks, create_tables, change_data_capture, clean_ups

--- a/src/dags/schiphol.py
+++ b/src/dags/schiphol.py
@@ -230,10 +230,7 @@ with DAG(
     )
 
     # 16. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 
 # FLOW

--- a/src/dags/spoorlijnen.py
+++ b/src/dags/spoorlijnen.py
@@ -183,7 +183,9 @@ slack_at_start >> mkdir >> download_data
 
 for data in zip(download_data):
 
-    data >> Interface >> SHP_to_SQL
+    data >> Interface
+
+Interface >> SHP_to_SQL
 
 for (create_SQL, create_table, revalidate_remove_geom_record, multi_check, rename_table,) in zip(
     SHP_to_SQL,
@@ -193,12 +195,11 @@ for (create_SQL, create_table, revalidate_remove_geom_record, multi_check, renam
     rename_tables,
 ):
 
-    [
-        create_SQL >> create_table >> revalidate_remove_geom_record
-    ] >> provenance_translation >> multi_check
+    [create_SQL >> create_table >> revalidate_remove_geom_record] >> provenance_translation
 
     [multi_check >> rename_table]
 
+provenance_translation >> multi_checks
 
 rename_tables >> grant_db_permissions
 

--- a/src/dags/sport.py
+++ b/src/dags/sport.py
@@ -339,24 +339,19 @@ with DAG(
 slack_at_start >> mk_tmp_dir >> (download_data_obs + download_data_maps)
 
 for data in download_data_obs:
-
-    data >> Interface >> cleanse_data
+    data >> Interface
 
 for data_maps in download_data_maps:
+    data_maps >> Interface
 
-    data_maps >> Interface >> cleanse_data
-
-for cleanse in cleanse_data:
-
-    cleanse >> Interface2 >> unique_id
+Interface >> cleanse_data >> Interface2 >> unique_id
 
 for (create_id, import_data) in zip(unique_id, load_data):
+    [create_id >> import_data] >> Interface3
 
-    [create_id >> import_data] >> Interface3 >> add_geom_col
+Interface3 >> add_geom_col
 
-for (add_geom, lookup_geom) in zip(add_geom_col, lookup_geometry_typeahead):
-
-    add_geom >> provenance_trans >> lookup_geom >> del_dupl_rows >> multi_checks
+add_geom_col >> provenance_trans >> lookup_geometry_typeahead >> del_dupl_rows >> multi_checks
 
 for (multi_check, create_table, check_changes, clean_up) in zip(
     multi_checks, create_tables, change_data_capture, clean_ups

--- a/src/dags/veiligeafstanden.py
+++ b/src/dags/veiligeafstanden.py
@@ -233,17 +233,16 @@ with DAG(
     )
 
     # 15. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dag_id
-    )
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
 
 # FLOW
 slack_at_start >> mkdir >> download_data
 
 for (data, change_seperator, import_data) in zip(download_data, change_seperators, CSV_to_DB):
 
-    [data >> change_seperator >> import_data] >> provenance_translation >> redefine_geoms
+    [data >> change_seperator >> import_data] >> provenance_translation
+
+provenance_translation >> redefine_geoms
 
 for (
     redefine_geom,


### PR DESCRIPTION
Some DAGs are using a placeholder operator `Interface` to converge a set of operator to one point in the DAG.

However, when operator connections to these interfaces are applied in a for loop, this lead to a lot of repetition for the operator-operator connection. Airflow issues warnings for this, since Airflow version 2. This leads to hundreds and hundreds of warnings, cluttering the console.

In this PR, the unwanted connections have been removed. Because this occurred in quite a lot of DAGs, this is a fairly large PR. However, all the changes are of the same type.

Most of these DAGs were not yet "blackened", this has been done in two separate commits.