### PR TITLE
[WIOR] added an upload step to store the data in the objectstore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
       AIRFLOW_CONN_OBJECTSTORE_MILIEUTHEMAS:
         "s3://milieuthemas:${MILIEUTHEMAS_PASSWD}@\
         e063b706cffc4002883c28d531f0234f"
+      AIRFLOW_CONN_OBJECTSTORE_VICTOR:
+        "s3://Victor:${VICTOR_PASSWD}@\
+        9c5404482acd43e488de31927f558201"
       AIRFLOW_CONN_SWIFT_DEFAULT: "s3://vsd_user:${VSD_PASSWD}@\
         4028c44d91dc48b8990069433c203c1f"
       AIRFLOW_CONN_GOB_GRAPHQL: "https://acc.api.data.amsterdam.nl/https"

--- a/src/dags/wior.py
+++ b/src/dags/wior.py
@@ -131,7 +131,7 @@ with DAG(
         swift_conn_id="OBJECTSTORE_VICTOR",
         action_type="delete",
         container="WIOR",
-        time_window_in_days=-1,
+        time_window_in_days=100,
     )
 
     # 6. Import data

--- a/src/plugins/swift_hook.py
+++ b/src/plugins/swift_hook.py
@@ -1,9 +1,14 @@
 import ntpath
 from contextlib import contextmanager
+from datetime import datetime, timezone, timedelta, tzinfo
+from dateutil import tz
 from pathlib import Path
 from airflow.hooks.base import BaseHook
 from airflow.exceptions import AirflowException
 from swiftclient.service import SwiftService, SwiftError, SwiftUploadObject
+from typing import Optional, Iterator, Dict
+
+to_zone: Optional[tzinfo] = tz.gettz("Europe/Amsterdam")
 
 
 class SwiftHook(BaseHook):
@@ -14,11 +19,17 @@ class SwiftHook(BaseHook):
     and OS_AUTH_URL, as requested by the SwiftService
     """
 
-    def __init__(self, swift_conn_id="swift_default"):
+    def __init__(self, swift_conn_id: str = "swift_default") -> None:
         self.swift_conn_id = swift_conn_id
 
     @contextmanager
-    def connection(self):
+    def connection(self) -> Iterator[SwiftService]:
+        """Setup the objectstore connection
+
+        Yields:
+            Iterator[SwiftService]:: An objectstore connection
+
+        """
         options = None
         if self.swift_conn_id != "swift_default":
             options = {}
@@ -28,7 +39,19 @@ class SwiftHook(BaseHook):
             options["os_tenant_name"] = connection.host
         yield SwiftService(options=options)
 
-    def list_container(self, container):
+    def list_container(self, container: str) -> Iterator[Dict]:
+        """Returns the items in the objectstore folder (container)
+
+        Args:
+            container (str): The objectstore folder to retreive the files
+
+        Raises:
+            AirflowException: Container cannot be listed
+
+        Yields:
+            Iterator[str]: Iterator[str]: Found file in given objectstor folder (container)
+
+        """
         with self.connection() as swift:
             try:
                 for page in swift.list(container=container):
@@ -39,7 +62,17 @@ class SwiftHook(BaseHook):
                 self.log.error(e.value)
                 raise AirflowException("Failed to fetch container listing") from e
 
-    def download(self, container, object_id, output_path):
+    def download(self, container: str, object_id: str, output_path: str) -> None:
+        """Downloads a file from the given folder (container)
+
+        Args:
+            container (str): Name of container of the objectstore to download to
+            object_id (str): File to download
+            output_path (str): Path to save to
+
+        Raises:
+            AirflowException: Download cannot be executed
+        """
         Path(output_path).parents[0].mkdir(parents=True, exist_ok=True)
         download_options = {
             "out_file": output_path,
@@ -61,7 +94,17 @@ class SwiftHook(BaseHook):
                 self.log.error(e.value)
                 raise AirflowException("Failed to fetch file") from e
 
-    def upload(self, container, local_path, object_id):  # noqa C901
+    def upload(self, container: str, local_path: str, object_id: str) -> None:  # noqa C901
+        """Upload file to given folder (container)
+
+        Args:
+            container (str): Name of container of the objectstore to download to
+            local_path (str): Path to upload to
+            object_id (str): File to upload
+
+        Raises:
+            AirflowException: Upload cannot be executed
+        """
         filename = ntpath.basename(local_path)
         with self.connection() as swift:
             try:
@@ -72,8 +115,10 @@ class SwiftHook(BaseHook):
                             local_path,
                             object_name=object_id,
                             options={
-                                'header':[f'content-disposition: attachment; filename="{filename}"']  # noqa
-                            }
+                                "header": [
+                                    f'content-disposition: attachment; filename="{filename}"'
+                                ]  # noqa
+                            },
                         )
                     ],
                 ):
@@ -100,3 +145,75 @@ class SwiftHook(BaseHook):
             except SwiftError as e:
                 self.log.error(e.value)
                 raise AirflowException("Failed to upload file") from e
+
+    def identify_files_not_in_timewindow(
+        self, container: str, time_window_in_days: int
+    ) -> Iterator[list]:
+
+        start_date: datetime = datetime.now(timezone.utc).astimezone(to_zone) - timedelta(
+            days=time_window_in_days
+        )
+        contents_of_container = self.list_container(container)
+        for file in contents_of_container:
+            modification_date = datetime.strptime(
+                file["last_modified"], "%Y-%m-%dT%H:%M:%S.%f"
+            ).astimezone(to_zone)
+            if modification_date < start_date:
+                yield file["name"]
+
+    def delete(
+        self, container: str, objects: list, time_window_in_days: Optional[int] = None
+    ) -> None:
+        """Deletes file(s) from the specified objectstore container based on:
+
+        - time window (days of retention span), or if not specified then
+        - list of files to delete
+
+        Args:
+            container (str): Name of objectstore container to execute delete
+            objects (list): Files to delete
+            time_window_in_days (Optional[int], optional): Maximum retention
+            time specified in days. If set all files, older then current day
+            and retention span in days, will be deleted. These files are
+            added to the objects list (the parameter above). Defaults to None.
+
+        Raises:
+            AirflowException: Raising error on issues while deleting files.
+        """
+
+        files_to_delete = (
+            [
+                file
+                for file in self.identify_files_not_in_timewindow(container, time_window_in_days)
+            ]
+            if time_window_in_days
+            else objects
+        )
+
+        with self.connection() as swift:
+            try:
+                if not files_to_delete:
+                    self.log.info("No files to delete...")
+                    return
+                del_iter = swift.delete(container=container, objects=files_to_delete)
+                for del_res in del_iter:
+                    c = del_res.get("container", "")
+                    o = del_res.get("object", "")
+                    a = del_res.get("attempts")
+                    if del_res["success"] and not del_res["action"] == "bulk_delete":
+                        rd = del_res.get("response_dict")
+                        if rd is not None:
+                            t = dict(rd.get("headers", {}))
+                            if t:
+                                self.log.info(
+                                    "Successfully deleted {0}/{1} in {2} attempts "
+                                    "(transaction id: {3})".format(c, o, a, t)
+                                )
+                            else:
+                                self.log.info(
+                                    "Successfully deleted {0}/{1} in {2} "
+                                    "attempts".format(c, o, a)
+                                )
+            except SwiftError as e:
+                self.log.error(e.value)
+                raise AirflowException("Failed to delete file(s):", objects) from e

--- a/src/plugins/swift_operator.py
+++ b/src/plugins/swift_operator.py
@@ -1,29 +1,81 @@
 from airflow.models.baseoperator import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from swift_hook import SwiftHook
+from typing import Dict, Any, Optional
 
 
 class SwiftOperator(BaseOperator):
-    @apply_defaults
+    @apply_defaults  # type: ignore
     def __init__(
         self,
         container: str,
-        object_id: str,
-        output_path: str,
+        object_id: Optional[str] = None,
+        output_path: Optional[str] = None,
+        action_type: str = "download",
+        objects_to_del: Optional[list] = None,
+        time_window_in_days: Optional[int] = None,
         swift_conn_id: str = "swift_default",
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Dict,
     ) -> None:
         self.container = container
         self.object_id = object_id
         self.output_path = output_path
+        self.action_type = action_type
+        self.objects_to_del = objects_to_del
+        self.time_window_in_days = time_window_in_days
         self.swift_conn_id = swift_conn_id
         super().__init__(*args, **kwargs)
 
-    def execute(self, context):
+    def execute(self, context: Optional[Dict[str, Any]] = None) -> None:
+        """Dispatcher to call the SwiftHook methods i.e. download, upload or delete.
 
-        self.log.info(
-            "Downloading: %s-%s to %s", self.container, self.object_id, self.output_path
-        )
-        self.hook = SwiftHook(swift_conn_id=self.swift_conn_id)
-        self.hook.download(self.container, self.object_id, self.output_path)
+        Args:
+            context: When this operator is created the context parameter is used
+                to refer to get_template_context for more context as part of
+                inheritance of the BaseOperator. It is set to None in this case.
+        """
+
+        if self.action_type == "download":
+            self.log.info(
+                "Downloading: %s-%s to %s", self.container, self.object_id, self.output_path
+            )
+            self.hook = SwiftHook(swift_conn_id=self.swift_conn_id)
+            self.hook.download(self.container, self.object_id, self.output_path)
+
+        elif self.action_type == "upload":
+
+            self.log.info(
+                "Uploading: %s-%s to %s", self.container, self.object_id, self.output_path
+            )
+            self.hook = SwiftHook(swift_conn_id=self.swift_conn_id)
+            self.hook.upload(
+                self.container,
+                self.output_path,
+                self.object_id,
+            )
+
+        elif self.action_type == "delete":
+
+            if self.time_window_in_days is not None:
+                self.log.info(
+                    "Deleting files from %s that are older then today minus %s days",
+                    self.container,
+                    self.time_window_in_days,
+                )
+            elif self.objects_to_del is not None:
+                self.log.info(
+                    "Deleting %s from %s",
+                    self.objects_to_del,
+                    self.container,
+                )
+            else:
+                self.log.error(
+                    "Nothing to delete...no time window or file given",
+                )
+
+            self.hook = SwiftHook(swift_conn_id=self.swift_conn_id)
+            self.hook.delete(self.container, self.objects_to_del, self.time_window_in_days)
+
+        else:
+            self.log.info("No action specified, do nothing")


### PR DESCRIPTION
Currently the WIOR (werken in openbare ruimte) data is partially served and processed in the database. To store the complete 'raw' data, its uploaded after download into the objectstore. The files are flagged with the current day so a history of data processing can be registred and serviced if needed to other consumers.