### PR TITLE
Changes to accommodate schematools for AB#4517

### DIFF
--- a/src/plugins/http_gob_operator.py
+++ b/src/plugins/http_gob_operator.py
@@ -18,7 +18,7 @@ from airflow.hooks.http_hook import HttpHook
 from airflow.exceptions import AirflowException
 from schematools import TMP_TABLE_POSTFIX
 from schematools.importer.ndjson import NDJSONImporter
-from schematools.utils import toCamelCase
+from schematools.utils import toCamelCase, schema_def_from_url
 
 
 from http_params_hook import HttpParamsHook
@@ -155,9 +155,10 @@ class HttpGobOperator(BaseOperator):
             # we know the schema, can be an input param (schema_def_from_url function)
             # We use the ndjson importer from schematools, give it a tmp tablename
             pg_hook = PostgresHook()
-            importer = NDJSONImporter(
-                dataset_info.dataset, pg_hook.get_sqlalchemy_engine(), logger=self.log
+            dataset = schema_def_from_url(
+                dataset_info.schema_url, dataset_info.dataset_id, prefetch_related=True
             )
+            importer = NDJSONImporter(dataset, pg_hook.get_sqlalchemy_engine(), logger=self.log)
 
             # Here we enter the schema-world, so table_name needs to be camelized
             # Or, should this be done later in the chain?

--- a/src/plugins/postgres_permissions_operator.py
+++ b/src/plugins/postgres_permissions_operator.py
@@ -159,6 +159,7 @@ class PostgresPermissionsOperator(BaseOperator):
                         ams_schema = schema_defs_from_url(
                             schemas_url=self.schema_url,
                             dataset_name=dataset_name,
+                            prefetch_related=True,
                         )
 
                         apply_schema_and_profile_permissions(
@@ -196,7 +197,9 @@ class PostgresPermissionsOperator(BaseOperator):
 
             try:
                 ams_schema = schema_defs_from_url(
-                    schemas_url=self.schema_url, dataset_name=self.dataset_name
+                    schemas_url=self.schema_url,
+                    dataset_name=self.dataset_name,
+                    prefetch_related=True,
                 )
 
                 apply_schema_and_profile_permissions(

--- a/src/plugins/sqlalchemy_create_object_operator.py
+++ b/src/plugins/sqlalchemy_create_object_operator.py
@@ -9,8 +9,7 @@ from environs import Env
 from more_ds.network.url import URL
 from schematools.cli import _get_engine
 from schematools.importer.base import BaseImporter
-from schematools.types import DatasetSchema, SchemaType
-from schematools.utils import schema_fetch_url_file
+from schematools.utils import schema_def_from_url
 from xcom_attr_assigner_mixin import XComAttrAssignerMixin
 
 env = Env()
@@ -104,15 +103,15 @@ class SqlAlchemyCreateObjectOperator(BaseOperator, XComAttrAssignerMixin):
         else:
             self.data_table_name = self.data_table_name
 
-        data_schema_url = SCHEMA_URL / self.data_schema_name / self.data_schema_name
-        data = schema_fetch_url_file(data_schema_url)
         engine = _get_engine(self.db_conn)
-        parent_schema = SchemaType(data)
-        dataset_schema = DatasetSchema(parent_schema)
-        importer = BaseImporter(dataset_schema, engine)
+        dataset_schema = schema_def_from_url(
+            SCHEMA_URL, self.data_schema_name, prefetch_related=True
+        )
+
+        importer = BaseImporter(dataset_schema, engine, logger=self.log)
         self.log.info(
-            "data_schema_url='%s', engine='%s', ind_table='%s', ind_extra_index='%s'.",
-            data_schema_url,
+            "schema_name='%s', engine='%s', ind_table='%s', ind_extra_index='%s'.",
+            self.data_schema_name,
             engine,
             self.ind_table,
             self.ind_extra_index,

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-amsterdam-schema-tools == 0.18.2
+amsterdam-schema-tools == 0.21.0
 cattrs == 1.1.2
 apache-airflow[crypto,postgres,sentry] == 2.0.1
 apache-airflow-providers-slack[http]==2.0.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@
 #
 alembic==1.5.5
     # via apache-airflow
-amsterdam-schema-tools==0.18.2
+amsterdam-schema-tools==0.21.0
     # via -r requirements.in
 apache-airflow-providers-ftp==1.0.1
     # via apache-airflow
@@ -206,6 +206,8 @@ jinja2==2.11.3
     #   flask-babel
     #   python-nvd3
     #   swagger-ui-bundle
+json-encoder==0.4.4
+    # via amsterdam-schema-tools
 jsonpath-rw==1.4.0
     # via amsterdam-schema-tools
 jsonpointer==2.0
@@ -260,6 +262,8 @@ marshmallow==3.10.0
     #   marshmallow-sqlalchemy
 mccabe==0.6.1
     # via flake8
+methodtools==0.4.2
+    # via amsterdam-schema-tools
 more-ds==0.0.3
     # via -r requirements.in
 msgpack==1.0.2
@@ -437,6 +441,8 @@ simple-singleton==1.1
     # via amsterdam-schema-tools
 simplejson==3.17.0
     # via -r requirements.in
+singledispatch==3.6.1
+    # via json-encoder
 six==1.15.0
     # via
     #   attrdict
@@ -444,6 +450,7 @@ six==1.15.0
     #   debtcollector
     #   docker
     #   flask-jwt-extended
+    #   json-encoder
     #   jsonpath-rw
     #   jsonschema
     #   keystoneauth1
@@ -454,9 +461,11 @@ six==1.15.0
     #   python-dateutil
     #   python-keystoneclient
     #   python-swiftclient
+    #   singledispatch
     #   sqlalchemy-utils
     #   tenacity
     #   websocket-client
+    #   wirerope
 slack-sdk==3.4.1
     # via apache-airflow-providers-slack
 sqlalchemy-jsonfield==1.0.0
@@ -466,6 +475,7 @@ sqlalchemy-utils==0.36.8
 sqlalchemy==1.3.23
     # via
     #   alembic
+    #   amsterdam-schema-tools
     #   apache-airflow
     #   flask-sqlalchemy
     #   geoalchemy2
@@ -508,6 +518,8 @@ werkzeug==1.0.1
     #   apache-airflow
     #   flask
     #   flask-jwt-extended
+wirerope==0.4.2
+    # via methodtools
 wrapt==1.12.1
     # via debtcollector
 wtforms==2.3.3


### PR DESCRIPTION
Some of the changes in `schematools v0.21.0` require adaptation of some DAGs and operators that are using `schematools`.

The first change is the introduction of `methodtools.lru_cache`. `DatasetSchema` objects were transferred between Airflow tasks
using xcom. However, xcom serializes the objects using python pickling which is not compatible with lru_cached methods.
So xcom has been changed to use only the ids of the datasets involved in inter-DAG communication.

Furthermore, to build up relations in `DatasetSchema` and `DatasetTable`, more information is needed. 
The dataset that provides the target-side of a relation needs to be available 
during construction of `DatasetSchema` and `-Table`.

A `prefetch_related` flag has been added to `schematools` functions to load the required datasets. 
The airflow operators using those function, needed an extra keyword argument to use the prefetching.
 