### PR TITLE
AB#6837 table creation solely based on schema

### DIFF
--- a/src/dags/beheerkaart.py
+++ b/src/dags/beheerkaart.py
@@ -76,7 +76,7 @@ with DAG(
         for data_table_name, db_table_name in tables.items()
     ]
 
-    # 3. load the dump file
+    # 4. load the dump file
     swift_load_task = SwiftLoadSqlOperator(
         task_id="swift_load_task",
         container="Dataservices",
@@ -87,7 +87,7 @@ with DAG(
         db_target_schema="pte",
     )
 
-    # 4. Make the provenance translations
+    # 5. Make the provenance translations
     provenance_renames = ProvenanceRenameOperator(
         task_id="provenance_renames",
         dataset_name=dataset_name,
@@ -97,13 +97,13 @@ with DAG(
         rename_indexes=True,
     )
 
-    # 5. Swap tables to target schema public
+    # 6. Swap tables to target schema public
     swap_schema = SwapSchemaOperator(task_id="swap_schema", dataset_name=dataset_name)
 
-    # 6. Create temporary directory
+    # 7. Create temporary directory
     mkdir = BashOperator(task_id="mkdir", bash_command=f"mkdir -p {tmp_dir}")
 
-    # 7. Create geopackage
+    # 8. Create geopackage
     create_geopackage = BashEnvOperator(
         task_id="create_geopackage",
         env={},
@@ -111,7 +111,7 @@ with DAG(
         bash_command=f'ogr2ogr -f GPKG {gpkg_path} PG:"tables={",".join(tables)}"',
     )
 
-    # 8. Zip geopackage
+    # 9. Zip geopackage
     zip_geopackage = BashEnvOperator(
         task_id="zip_geopackage",
         env={},
@@ -119,7 +119,7 @@ with DAG(
         bash_command=f"zip -j {gpkg_path}.zip {gpkg_path}",
     )
 
-    # 9. Upload geopackage to datacatalog
+    # 10. Upload geopackage to datacatalog
     upload_data = DCATSwiftOperator(
         environment=DATAPUNT_ENVIRONMENT,
         task_id="upload_data",
@@ -128,7 +128,7 @@ with DAG(
         distribution_id="1",
     )
 
-    # 10. Grant database permissions
+    # 11. Grant database permissions
     grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dataset_name)
 
 # FLOW

--- a/src/dags/beheerkaart.py
+++ b/src/dags/beheerkaart.py
@@ -8,6 +8,8 @@ from provenance_drop_from_schema_operator import ProvenanceDropFromSchemaOperato
 from swap_schema_operator import SwapSchemaOperator
 from dcat_swift_operator import DCATSwiftOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
+from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
+
 
 from common import (
     default_args,
@@ -23,7 +25,11 @@ DATASTORE_TYPE = "acceptance" if DATAPUNT_ENVIRONMENT == "development" else DATA
 
 dag_id = "beheerkaart"
 tmp_dir = f"{SHARED_DIR}/{dag_id}"
-tables = "beheerkaart_basis_bgt,beheerkaart_basis_eigendomsrecht,beheerkaart_basis_kaart"
+tables = {
+    "beheerkaart_basis_bgt": "bkt_bgt",
+    "beheerkaart_basis_eigendomsrecht": "bkt_eigendomsrecht",
+    "beheerkaart_basis_kaart": "bkt_beheerkaart_basis",
+}
 
 dataset_name = f"{dag_id}_basis"
 gpkg_path = f"{tmp_dir}/{dataset_name}.gpkg"
@@ -54,6 +60,22 @@ with DAG(
         pg_schema="pte",
     )
 
+    # 3. Create tables in target schema PTE
+    # based upon presence in the Amsterdam schema definition
+    create_tables = [
+        SqlAlchemyCreateObjectOperator(
+            task_id=f"create_{db_table_name}",
+            data_schema_name=dataset_name,
+            pg_schema="pte",
+            data_table_name=data_table_name,
+            db_table_name=db_table_name,
+            ind_table=True,
+            # when set to false, it doesn't create indexes; only tables
+            ind_extra_index=True,
+        )
+        for data_table_name, db_table_name in tables.items()
+    ]
+
     # 3. load the dump file
     swift_load_task = SwiftLoadSqlOperator(
         task_id="swift_load_task",
@@ -70,6 +92,8 @@ with DAG(
         task_id="provenance_renames",
         dataset_name=dataset_name,
         pg_schema="pte",
+        prefix_table_name=f"{dataset_name}_",
+        postfix_table_name="_new",
         rename_indexes=True,
     )
 
@@ -84,7 +108,7 @@ with DAG(
         task_id="create_geopackage",
         env={},
         env_expander=fetch_pg_env_vars,
-        bash_command=f'ogr2ogr -f GPKG {gpkg_path} PG:"tables={tables}"',
+        bash_command=f'ogr2ogr -f GPKG {gpkg_path} PG:"tables={",".join(tables)}"',
     )
 
     # 8. Zip geopackage
@@ -104,11 +128,13 @@ with DAG(
         distribution_id="1",
     )
 
-     # 10. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(
-        task_id="grants",
-        dag_name=dataset_name
-    )
+    # 10. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dataset_name)
 
 # FLOW
-slack_at_start >> drop_tables >> swift_load_task >> provenance_renames >> swap_schema >> mkdir >> create_geopackage >> zip_geopackage >> upload_data >> grant_db_permissions  # noqa
+slack_at_start >> drop_tables >> create_tables
+
+for table in create_tables:
+    table >> swift_load_task
+
+swift_load_task >> provenance_renames >> swap_schema >> mkdir >> create_geopackage >> zip_geopackage >> upload_data >> grant_db_permissions  # noqa

--- a/src/dags/beheerkaart.py
+++ b/src/dags/beheerkaart.py
@@ -143,6 +143,15 @@ with DAG(
 slack_at_start >> drop_tables >> create_tables
 
 for table in create_tables:
-    table >> swift_load_task
+    table >> rename_cols
 
-rename_cols >> swift_load_task >> provenance_renames >> swap_schema >> mkdir >> create_geopackage >> zip_geopackage >> upload_data >> grant_db_permissions  # noqa
+(   rename_cols
+    >> swift_load_task
+    >> provenance_renames
+    >> swap_schema
+    >> mkdir
+    >> create_geopackage
+    >> zip_geopackage
+    >> upload_data
+    >> grant_db_permissions
+    )

--- a/src/dags/sql/beheerkaart_basis.py
+++ b/src/dags/sql/beheerkaart_basis.py
@@ -1,0 +1,8 @@
+# The source defines a different name for the ID column
+# before insert data the source column name must be present
+# after insert it can be translated by the provenance operator
+RENAME_COLS = """
+ALTER TABLE pte.bkt_bgt RENAME COLUMN id TO bk_bkt_bgt;
+ALTER TABLE pte.bkt_eigendomsrecht RENAME COLUMN id TO bk_bkt_eigendomsrecht;
+ALTER TABLE pte.bkt_beheerkaart_basis RENAME COLUMN id TO bk_bkt_beheerkaart_basis;
+"""

--- a/src/plugins/sqlalchemy_create_object_operator.py
+++ b/src/plugins/sqlalchemy_create_object_operator.py
@@ -108,15 +108,8 @@ class SqlAlchemyCreateObjectOperator(BaseOperator, XComAttrAssignerMixin):
             self.data_table_name = self.data_table_name
 
         # setup the database schema for the database connection
-        if self.pg_schema is not None:
-            engine = _get_engine(
-                self.db_conn,
-                pg_schemas=[
-                    self.pg_schema,
-                ],
-            )
-        else:
-            engine = _get_engine(self.db_conn)
+        kwargs = {"pg_schemas": [self.pg_schema]} if self.pg_schema is not None else {}
+        engine = _get_engine(self.db_conn, **kwargs)
 
         dataset_schema = schema_def_from_url(
             SCHEMA_URL, self.data_schema_name, prefetch_related=True


### PR DESCRIPTION
The existing DAG beheerkaartbasis was lacking the table creation based on the schema defintion. Also the whishes of the users were to create the database objects and it's comments on the schema defintion structure and it's description fields.

The existing DAG was enriched by the extra step of creating the database objects. However, the source data are SQL copy statements that reference a different schema then public. So the tables to be created had to be created in the specified schema as the source copy statements dictated (the PTE schema). The schema option was already available as a paramater in the create objects method from schema-tools. So it could be set.

Also temorary database tables names, as stated in the copy SQL statements from source file, was an option to set. This way the data structure could be created solely from the schema and the source SQL copy statements could be excuted to insert the data.