### PR TITLE
Precariobelasting

### DIFF
--- a/src/dags/precariobelasting.py
+++ b/src/dags/precariobelasting.py
@@ -102,11 +102,11 @@ with DAG(
     extract_geojsons = [
         BashOperator(
             task_id=f"extract_geojson_{file_name}",
-            bash_command=f"ogr2ogr -f 'PGDump' "
-            f"-t_srs EPSG:28992 "
+            bash_command="ogr2ogr -f 'PGDump' "
+            "-t_srs EPSG:28992 "
             f"-nln {file_name} "
             f"{tmp_dir}/{file_name}.sql {tmp_dir}/{url} "
-            f"-lco FID=ID -lco GEOMETRY_NAME=geometry ",
+            "-lco FID=ID -lco GEOMETRY_NAME=geometry ",
         )
         for file_name, url in data_endpoints.items()
     ]
@@ -131,7 +131,7 @@ with DAG(
             COUNT_CHECK.make_check(
                 check_id=f"count_check_{file_name}",
                 pass_value=2,
-                params=dict(table_name=f"{file_name}"),
+                params=dict(table_name=file_name),
                 result_checker=operator.ge,
             )
         )
@@ -140,7 +140,7 @@ with DAG(
             GEO_CHECK.make_check(
                 check_id=f"geo_check_{file_name}",
                 params=dict(
-                    table_name=f"{file_name}",
+                    table_name=file_name,
                     geotype=["POLYGON", "MULTIPOLYGON"],
                 ),
                 pass_value=1,
@@ -148,19 +148,19 @@ with DAG(
         )
 
         total_checks = count_checks + geo_checks
-        check_name[f"{file_name}"] = total_checks
+        check_name[file_name] = total_checks
 
     # 8. Execute bundled checks (step 7) on database
     multi_checks = [
         PostgresMultiCheckOperator(
-            task_id=f"multi_check_{file_name}", checks=check_name[f"{file_name}"]
+            task_id=f"multi_check_{file_name}", checks=check_name[file_name]
         )
         for file_name in data_endpoints.keys()
     ]
 
     # 10. RENAME columns based on PROVENANCE
     provenance_translation = ProvenanceRenameOperator(
-        task_id="rename_columns", dataset_name=f"{dag_id}", pg_schema="public"
+        task_id="rename_columns", dataset_name=dag_id, pg_schema="public"
     )
 
     # 11. DROP Exisiting TABLE
@@ -178,7 +178,7 @@ with DAG(
     rename_tables = [
         PostgresTableRenameOperator(
             task_id=f"rename_table_{file_name}",
-            old_table_name=f"{file_name}",
+            old_table_name=file_name,
             new_table_name=f"{dag_id}_{file_name}",
         )
         for file_name in data_endpoints.keys()

--- a/src/dags/precariobelasting.py
+++ b/src/dags/precariobelasting.py
@@ -1,4 +1,5 @@
-import operator, re
+import operator
+import re
 
 from airflow import DAG
 from airflow.models import Variable
@@ -7,10 +8,11 @@ from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 
-from http_fetch_operator import HttpFetchOperator
+from swift_operator import SwiftOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
+from typing import Dict
 
 from common import (
     default_args,
@@ -19,6 +21,7 @@ from common import (
     DATAPUNT_ENVIRONMENT,
     SHARED_DIR,
     MessageOperator,
+    quote_string,
 )
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
@@ -31,26 +34,24 @@ from sql.precariobelasting_add import (
     RENAME_DATAVALUE_GEBIED,
 )
 
-dag_id = "precariobelasting"
-variables = Variable.get(dag_id, deserialize_json=True)
-tmp_dir = f"{SHARED_DIR}/{dag_id}"
-data_endpoints = variables["data_endpoints"]
-data_endpoints = variables["temp_data"]
-metadataschema_endpoint = variables["metadataschema_endpoint"]
-metadataschema_file = f"{tmp_dir}/precariobelasting_metadataschema.json"
-total_checks = []
-count_checks = []
-geo_checks = []
-check_name = {}
-
-
-# needed to put quotes on elements in geotypes for SQL_CHECK_GEO
-def quote(instr):
-    return f"'{instr}'"
+dag_id: str = "precariobelasting"
+variables: dict = Variable.get(dag_id, deserialize_json=True)
+tmp_dir: str = f"{SHARED_DIR}/{dag_id}"
+data_endpoints: Dict[str, str] = variables["temp_data"]
+total_checks: list = []
+count_checks: list = []
+geo_checks: list = []
+check_name: dict = {}
 
 
 # remove space hyphen characters
-def clean_data(file_name):
+def clean_data(file_name: str) -> None:
+    """Cleans the data content of the given file.
+    Translates non-ASCII characters: '\xc2\xad' to None
+
+    Args:
+        file_name: Name of file to clean data
+    """
     data = open(file_name, "r").read()
     result = re.sub(r"[\xc2\xad]", "", data)
     with open(file_name, "w") as output:
@@ -60,7 +61,7 @@ def clean_data(file_name):
 with DAG(
     dag_id,
     default_args=default_args,
-    user_defined_filters=dict(quote=quote),
+    user_defined_filters=dict(quote=quote_string),
 ) as dag:
 
     # 1. Post message on slack
@@ -75,39 +76,39 @@ with DAG(
     # 2. create download temp directory to store the data
     mk_tmp_dir = BashOperator(task_id="mk_tmp_dir", bash_command=f"mkdir -p {tmp_dir}")
 
-    # 3. download the data into temp directory
+    # 3. Download data
     download_data = [
-        HttpFetchOperator(
+        SwiftOperator(
             task_id=f"download_{file_name}",
-            endpoint=url,
-            http_conn_id="airflow_home_conn_id",
-            tmp_file=f"{tmp_dir}/{file_name}.json",
-            output_type="file",
+            swift_conn_id="objectstore_dataservices",
+            container="Dataservices",
+            object_id=url,
+            output_path=f"{tmp_dir}/{url}",
         )
         for file_name, url in data_endpoints.items()
     ]
 
     # 4. Cleanse the downloaded data (remove the space hyphen characters)
-    clean_data = [
+    clean_up_data = [
         PythonOperator(
             task_id=f"clean_data_{file_name}",
             python_callable=clean_data,
-            op_args=[f"{tmp_dir}/{file_name}.json"],
+            op_args=[f"{tmp_dir}/{url}"],
         )
-        for file_name in data_endpoints.keys()
+        for file_name, url in data_endpoints.items()
     ]
 
     # 5.create the SQL for creating the table using ORG2OGR PGDump
     extract_geojsons = [
         BashOperator(
             task_id=f"extract_geojson_{file_name}",
-            bash_command="ogr2ogr -f 'PGDump' "
-            "-t_srs EPSG:28992 "
+            bash_command=f"ogr2ogr -f 'PGDump' "
+            f"-t_srs EPSG:28992 "
             f"-nln {file_name} "
-            f"{tmp_dir}/{file_name}.sql {tmp_dir}/{file_name}.json "
-            "-lco FID=ID -lco GEOMETRY_NAME=geometry ",
+            f"{tmp_dir}/{file_name}.sql {tmp_dir}/{url} "
+            f"-lco FID=ID -lco GEOMETRY_NAME=geometry ",
         )
-        for file_name in data_endpoints.keys()
+        for file_name, url in data_endpoints.items()
     ]
 
     # 6. Load data into the table
@@ -130,7 +131,7 @@ with DAG(
             COUNT_CHECK.make_check(
                 check_id=f"count_check_{file_name}",
                 pass_value=2,
-                params=dict(table_name=file_name),
+                params=dict(table_name=f"{file_name}"),
                 result_checker=operator.ge,
             )
         )
@@ -139,7 +140,7 @@ with DAG(
             GEO_CHECK.make_check(
                 check_id=f"geo_check_{file_name}",
                 params=dict(
-                    table_name=file_name,
+                    table_name=f"{file_name}",
                     geotype=["POLYGON", "MULTIPOLYGON"],
                 ),
                 pass_value=1,
@@ -147,19 +148,19 @@ with DAG(
         )
 
         total_checks = count_checks + geo_checks
-        check_name[file_name] = total_checks
+        check_name[f"{file_name}"] = total_checks
 
     # 8. Execute bundled checks (step 7) on database
     multi_checks = [
         PostgresMultiCheckOperator(
-            task_id=f"multi_check_{file_name}", checks=check_name[file_name]
+            task_id=f"multi_check_{file_name}", checks=check_name[f"{file_name}"]
         )
         for file_name in data_endpoints.keys()
     ]
 
     # 10. RENAME columns based on PROVENANCE
     provenance_translation = ProvenanceRenameOperator(
-        task_id="rename_columns", dataset_name=dag_id, pg_schema="public"
+        task_id="rename_columns", dataset_name=f"{dag_id}", pg_schema="public"
     )
 
     # 11. DROP Exisiting TABLE
@@ -177,7 +178,7 @@ with DAG(
     rename_tables = [
         PostgresTableRenameOperator(
             task_id=f"rename_table_{file_name}",
-            old_table_name=file_name,
+            old_table_name=f"{file_name}",
             new_table_name=f"{dag_id}_{file_name}",
         )
         for file_name in data_endpoints.keys()
@@ -193,7 +194,9 @@ with DAG(
         for file_name in data_endpoints.keys()
     ]
 
-    # 14. Dummy operator is used act as an interface between one set of parallel tasks to another parallel taks set (without this intermediar Airflow will give an error)
+    # 14. Dummy operator is used act as an interface
+    # between one set of parallel tasks to another parallel taks set
+    # (without this intermediar Airflow will give an error)
     Interface = DummyOperator(task_id="interface")
 
     # 15. Add derived columns (only woonschepen en bedrijfsvaartuigen are missing gebied as column)
@@ -206,7 +209,8 @@ with DAG(
         for file_name in ["woonschepen", "bedrijfsvaartuigen"]
     ]
 
-    # 16. rename values in column gebied for terrassen en passagiersvaartuigen (woonschepen en bedrijfsvaartuigen are added in the previous step)
+    # 16. rename values in column gebied for terrassen en passagiersvaartuigen
+    # (woonschepen en bedrijfsvaartuigen are added in the previous step)
     rename_value_gebieden = [
         PostgresOperator(
             task_id=f"rename_value_{file_name}",
@@ -224,7 +228,7 @@ with DAG(
 
     for (
         data,
-        clean_data,
+        clean_up_data,
         extract_geojson,
         load_table,
         multi_check,
@@ -233,7 +237,7 @@ with DAG(
         rename_table,
     ) in zip(
         download_data,
-        clean_data,
+        clean_up_data,
         extract_geojsons,
         load_tables,
         multi_checks,
@@ -243,7 +247,7 @@ with DAG(
     ):
 
         [
-            data >> clean_data >> extract_geojson >> load_table >> multi_check
+            data >> clean_up_data >> extract_geojson >> load_table >> multi_check
         ] >> provenance_translation
 
         [drop_table >> rename_table >> add_title_column] >> Interface

--- a/src/plugins/http_fetch_operator.py
+++ b/src/plugins/http_fetch_operator.py
@@ -83,17 +83,6 @@ class HttpFetchOperator(BaseOperator):
 
         tmp_file: Path = Path(self.tmp_file)
 
-        # ----- TEMPORARY IF REMOVE IT AFTER precariobelasting HAS DATA ON OBJECTSTORE PRD -----
-        if self.output_type == "file":
-            self.log.info("Output type: 'file'. Current working directory '%s'", os.getcwd())
-            with open(self.endpoint) as source:
-                data = source.read()
-
-            with open(tmp_file, "wt") as wf:
-                wf.write(data)
-            return
-        # ----- TEMPORARY IF REMOVE IT AFTER precariobelasting HAS DATA ON OBJECTSTORE PRD -----
-
         if self.xcom_tmp_dir_task_ids is not None:
             self.log.debug(
                 "Retrieving tmp dir from XCom: task_ids='%s', key='%s'.",

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -136,7 +136,7 @@ flake8==3.9.2
     # via
     #   -r requirements.in
     #   flake8-colors
-flask-appbuilder==3.1.1
+flask-appbuilder==3.3.0
     # via apache-airflow
 flask-babel==1.0.0
     # via flask-appbuilder

--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -166,7 +166,7 @@ sport:
   files_to_download:
     csv:
       zwembad: dcatd/datasets/o-HEFxsOggSf8A/purls/bjpABHIt0g6IyQ
-      sportaanbieder: dcatd/datasets/a6WW_Ay-oeY_dQ/purls/aT3gGdCZycJHjg
+      sportaanbieder: dcatd/datasets/a6WW_Ay-oeY_dQ/purls/2
       gymsportzaal: dcatd/datasets/XtEra6am2lDbHg/purls/gL_MLa12hbigZA
       sporthal: dcatd/datasets/o-HEFxsOggSf8A/purls/bjpABHIt0g6IyQ
     geojson:

--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -77,12 +77,11 @@ precariobelasting:
     passagiersvaartuigen: dcatd/datasets/aUBH75WzCsTcYQ/purls/4
     woonschepen: dcatd/datasets/aUBH75WzCsTcYQ/purls/2
     terrassen: dcatd/datasets/aUBH75WzCsTcYQ/purls/1
-  metadataschema_endpoint: datasets/precariobelasting/precariobelasting
   temp_data:
-    bedrijfsvaartuigen: data/precariobelasting/bedrijfsvaartuigen.geojson
-    passagiersvaartuigen: data/precariobelasting/passagiersvaartuigen.geojson
-    woonschepen: data/precariobelasting/woonschepen.geojson
-    terrassen: data/precariobelasting/terrassen.geojson
+    bedrijfsvaartuigen: precariobelasting/bedrijfsvaartuigen.geojson
+    passagiersvaartuigen: precariobelasting/passagiersvaartuigen.geojson
+    woonschepen: precariobelasting/woonschepen.geojson
+    terrassen: precariobelasting/terrassen.geojson
 touringcars:
   data_endpoints:
     aanbevolenroutes: dcatd/datasets/IuAYhr-__qZj9Q/purls/wFSs8bEzvW7S9w


### PR DESCRIPTION
TEMPORARY rule was removed from http_fetch_operator specifically for precariobelasting. It retrieved data from with the containter itself. Now it looks for the data from the dataservices objectstore. The additional logical for the TEMPORARY data storage is not needed anymore.