### PR TITLE
Check for broken dags during deployment

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -66,6 +66,7 @@ COPY scripts/docker-entrypoint.sh /docker-entrypoint.sh
 COPY scripts/run.sh /run.sh
 COPY scripts/mkvars.py ${AIRFLOW_USER_HOME}/scripts/mkvars.py
 COPY scripts/mkuser.py ${AIRFLOW_USER_HOME}/scripts/mkuser.py
+COPY scripts/checkdags.py ${AIRFLOW_USER_HOME}/scripts/checkdags.py
 RUN chmod +x /docker-entrypoint.sh /run.sh
 COPY config/airflow.cfg ${AIRFLOW_USER_HOME}/airflow.cfg
 RUN mkdir ${AIRFLOW_USER_HOME}/etc

--- a/src/scripts/checkdags.py
+++ b/src/scripts/checkdags.py
@@ -1,0 +1,21 @@
+"""Python script to check for broken DAGs.
+
+This scripts is running during the initialization and startup of Airflow during deployment.
+When DAGs are broken, this results in Airflow not being able to start.
+So, broken dags are detected during deployment.
+"""
+
+from pathlib import Path
+import subprocess
+
+
+dagsfolder = Path(__file__).parent / ".." / "dags"
+
+broken_dags = []
+for dagfile in dagsfolder.glob("*.py"):
+    proc = subprocess.run(["python", dagfile])
+    if proc.returncode != 0:
+        broken_dags.append(dagfile.name)
+
+if broken_dags:
+    raise Exception("These dags are broken: {}".format(", ".join(broken_dags)))

--- a/src/scripts/run.sh
+++ b/src/scripts/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e # stop on errors
+
 export AIRFLOW__CORE__SQL_ALCHEMY_CONN=${AIRFLOW__CORE__SQL_ALCHEMY_CONN:-`echo $AIRFLOW_CONN_POSTGRES_DEFAULT | cut -d'?' -f 1`}
 export AIRFLOW_CONN_POSTGRES_VSD={$AIRFLOW_CONN_POSTGRES_VSD:-$AIRFLOW__CORE__SQL_ALCHEMY_CONN}
 airflow db init  # db init is not destructive, so can be re-run at startup
@@ -82,5 +85,16 @@ airflow connections add rdw_conn_id \
 # airflow scheduler &
 # airflow webserver
 airflow variables import vars/vars.json
+
+# Check all dags by running them as python modules.
+# This is whait the Airflow dagbag is also doing.
+# If one of the DAGs fails, the check script exits
+# with a non-zero exit state.
+# A fully configured Airflow instance is needed to be able
+# to run the checkscript.
+# Make sure that the the containing shell script (run.sh)
+# stops on errors (set -e).
+python scripts/checkdags.py
+
 # sleep infinity
 /usr/local/bin/supervisord --config /usr/local/airflow/etc/supervisord.conf


### PR DESCRIPTION
This python script is added to the initialization and startup of Airflow (in run.sh).
This makes the deployment fail, so broken dags are detected immediately during deployment.