### PR TITLE
Moved `set -e` closer to execution scripts/checkdags.py

### DIFF
--- a/src/scripts/run.sh
+++ b/src/scripts/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e # stop on errors
-
 export AIRFLOW__CORE__SQL_ALCHEMY_CONN=${AIRFLOW__CORE__SQL_ALCHEMY_CONN:-`echo $AIRFLOW_CONN_POSTGRES_DEFAULT | cut -d'?' -f 1`}
 export AIRFLOW_CONN_POSTGRES_VSD={$AIRFLOW_CONN_POSTGRES_VSD:-$AIRFLOW__CORE__SQL_ALCHEMY_CONN}
 airflow db init  # db init is not destructive, so can be re-run at startup
@@ -94,6 +92,7 @@ airflow variables import vars/vars.json
 # to run the checkscript.
 # Make sure that the the containing shell script (run.sh)
 # stops on errors (set -e).
+set -e
 python scripts/checkdags.py
 
 # sleep infinity

--- a/src/scripts/run.sh
+++ b/src/scripts/run.sh
@@ -92,8 +92,7 @@ airflow variables import vars/vars.json
 # to run the checkscript.
 # Make sure that the the containing shell script (run.sh)
 # stops on errors (set -e).
-set -e
-python scripts/checkdags.py
+python scripts/checkdags.py || exit
 
 # sleep infinity
 /usr/local/bin/supervisord --config /usr/local/airflow/etc/supervisord.conf


### PR DESCRIPTION
The set -e configuration in run.sh is used to stop Airflow when one of the DAG's cannot be executed due to some error. An extra safety check before deployment of changes.

In the run.sh one of the cmd's is to delete and create Airflow connections. When runned locally (for the first time) the connection are not yet created when the cmd to delete the connection is executed (after that it will create the connection).

Because the connection does not yet exists when deleted, it will give an exit code 1. Causing the Airflow to stop running.

As a quick fic the `set -e` is set just befor e the scripts/checkdags.py. So it will be active for the check on correct DAG.