### PR TITLE
Broken DAG parkeerzones

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -516,7 +516,7 @@ typing-extensions==3.7.4.3
     # via rich
 unicodecsv==0.14.1
     # via apache-airflow
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
For some time the DAG parkeerzones executed with errors due to an incorrect flow definition. Most likely the flow definition was accidentally adjusted resulting in a broken pipeline. This flowchain is therefore fixed + some flake8 and mypy adjustments.