### PR TITLE
AB#4367 notify source owners failed import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ dmypy.json
 
 # IntelliJ based IDEs
 .idea/
+
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,15 @@ dmypy.json
 # IntelliJ based IDEs
 .idea/
 
+# Visual Studio Code IDE
 .vscode/
+
+# Real config lives in src/config/airflow.cfg
+# ignored path is symlink to allow it run locally with
+# export AIRFLOW_HOME=$(pwd)/src
+src/airflow.cfg
+
+# When running locally a webserver_config
+# will be created with default values.
+# This too should not be checked in.
+src/webserver_config.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": ".venv/bin/python3.8"
-}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
 .PHONY: install
 install:
 	pip install -r requirements_dev.txt
+	pre-commit clean
 	pre-commit install
 
 .PHONY: sync

--- a/src/dags/aardgasvrijezones.py
+++ b/src/dags/aardgasvrijezones.py
@@ -13,6 +13,7 @@ from common import (
     SHARED_DIR,
     MessageOperator,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -43,6 +44,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/anpr.py
+++ b/src/dags/anpr.py
@@ -5,6 +5,8 @@ from airflow.hooks.postgres_hook import PostgresHook
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from http_fetch_operator import HttpFetchOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 
@@ -79,6 +81,7 @@ with DAG(
     dag_id,
     default_args=args,
     description="aantal geidentificeerde taxikentekenplaten per dag",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. starting message on Slack

--- a/src/dags/asbest.py
+++ b/src/dags/asbest.py
@@ -2,6 +2,8 @@ from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_permissions_operator import PostgresPermissionsOperator
 
 # from airflow.operators.postgres_operator import PostgresOperator
@@ -27,6 +29,7 @@ dag_config = Variable.get(dag_id, deserialize_json=True)
 with DAG(
     dag_id,
     default_args=default_args,
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id="asbestdaken")
 ) as dag:
 
     extract_shps = []

--- a/src/dags/basiskaart.py
+++ b/src/dags/basiskaart.py
@@ -7,6 +7,7 @@ from airflow.models import Variable
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from common import DATAPUNT_ENVIRONMENT, MessageOperator, default_args, env, slack_webhook_token
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from dynamic_dagrun_operator import TriggerDynamicDagRunOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -123,6 +124,7 @@ def create_basiskaart_dag(is_first: bool, table_name: str, select_statement: str
         basisregistratie grootschalige topologie (BGT) en kleinschalige basiskaart (KBK10 en 50).
         The basiskaart data is collected from basiskaart DB.""",
         tags=["basiskaart"],
+        on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
     )
 
     with dag:

--- a/src/dags/basiskaart.py
+++ b/src/dags/basiskaart.py
@@ -11,6 +11,9 @@ from dynamic_dagrun_operator import TriggerDynamicDagRunOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 from provenance_rename_operator import ProvenanceRenameOperator
+
+# These seemingly unused imports are actually used, albeit indirectly. See the code with
+# `globals()[select_statement]`. Hence the `noqa: F401` comments.
 from sql.basiskaart import CREATE_MVIEWS, CREATE_TABLES
 from sql.basiskaart import SELECT_GEBOUWVLAK_SQL as SELECT_GEBOUWVLAK_SQL  # noqa: F401
 from sql.basiskaart import (  # noqa: F401

--- a/src/dags/bedrijveninvesteringszone.py
+++ b/src/dags/bedrijveninvesteringszone.py
@@ -7,6 +7,7 @@ from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from provenance_rename_operator import ProvenanceRenameOperator
 
 from postgres_rename_operator import PostgresTableRenameOperator
@@ -54,6 +55,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/beheerkaart.py
+++ b/src/dags/beheerkaart.py
@@ -2,6 +2,7 @@ from airflow import DAG
 from airflow.operators.bash import BashOperator
 
 from bash_env_operator import BashEnvOperator
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from swift_load_sql_operator import SwiftLoadSqlOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from provenance_drop_from_schema_operator import ProvenanceDropFromSchemaOperator
@@ -35,6 +36,7 @@ with DAG(
     # New data is delivered every wednesday and friday evening,
     # So we schedule the import on friday and saturday morning
     schedule_interval="0 0 * * 4,6",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id="beheerkaart_basis")
 ) as dag:
     # 1. Post message on slack
     slack_at_start = MessageOperator(

--- a/src/dags/bekendmakingen.py
+++ b/src/dags/bekendmakingen.py
@@ -5,6 +5,7 @@ from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from http_fetch_operator import HttpFetchOperator
 
 from provenance_rename_operator import ProvenanceRenameOperator
@@ -46,6 +47,7 @@ with DAG(
     default_args=default_args,
     template_searchpath=["/"],
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/blackspots.py
+++ b/src/dags/blackspots.py
@@ -1,5 +1,7 @@
 from airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from swift_load_sql_operator import SwiftLoadSqlOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 
@@ -64,6 +66,7 @@ dag_id = "blackspots"
 with DAG(
     dag_id,
     default_args=default_args,
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     slack_at_start = MessageOperator(

--- a/src/dags/bodem.py
+++ b/src/dags/bodem.py
@@ -13,6 +13,7 @@ from common import (
     SHARED_DIR,
     MessageOperator,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -44,6 +45,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/bouwstroompunten.py
+++ b/src/dags/bouwstroompunten.py
@@ -17,6 +17,7 @@ from common import (
     SHARED_DIR,
     MessageOperator,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -80,6 +81,7 @@ with DAG(
     default_args=default_args,
     template_searchpath=["/"],
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/cmsa.py
+++ b/src/dags/cmsa.py
@@ -12,6 +12,7 @@ from common import (
     default_args,
     slack_webhook_token,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from http_fetch_operator import HttpFetchOperator
 from importscripts.import_cmsa import import_cmsa
 from postgres_files_operator import PostgresFilesOperator
@@ -48,6 +49,7 @@ with DAG(
                 3D sensoren, wifi sensoren, (tel)camera's en beacons""",
     default_args=default_args,
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/common/__init__.py
+++ b/src/dags/common/__init__.py
@@ -111,6 +111,7 @@ def slack_failed_task(context: Context) -> None:
     dag_id: str = context["dag"].dag_id
     task_id: str = context["task"].task_id
     exception: Optional[BaseException] = context.get("exception")
+    formatted_exception = ""
     if exception is not None:
         formatted_exception = "".join(
             traceback.format_exception(

--- a/src/dags/covid_19.py
+++ b/src/dags/covid_19.py
@@ -4,6 +4,7 @@ from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -53,6 +54,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/crowdmonitor.py
+++ b/src/dags/crowdmonitor.py
@@ -7,6 +7,7 @@ from airflow.operators.python_operator import PythonOperator
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from common import env, default_args
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_permissions_operator import PostgresPermissionsOperator
 
 dag_id = "crowdmonitor"
@@ -147,7 +148,12 @@ def copy_data_in_batch(fetch_iterator, periode="uur"):
 
 args = default_args.copy()
 
-with DAG(dag_id, default_args=args, description="Crowd Monitor",) as dag:
+with DAG(
+     dag_id,
+     default_args=args,
+     description="Crowd Monitor",
+     on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
+) as dag:
     create_temp_tables = PostgresOperator(
         task_id="create_temp_tables",
         sql=SQL_CREATE_TEMP_TABLE,

--- a/src/dags/deelmobiliteit.py
+++ b/src/dags/deelmobiliteit.py
@@ -7,6 +7,8 @@ from airflow.operators.dummy_operator import DummyOperator
 from common.db import DatabaseEngine
 from environs import Env
 from more_ds.network.url import URL
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from provenance_rename_operator import ProvenanceRenameOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
@@ -62,6 +64,7 @@ with DAG(
     description=description,
     default_args=default_args,
     user_defined_filters=dict(quote=quote_string),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/evenementen.py
+++ b/src/dags/evenementen.py
@@ -7,7 +7,7 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.postgres_operator import PostgresOperator
 
-
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -66,6 +66,7 @@ with DAG(
     default_args=default_args,
     template_searchpath=["/"],
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/explosieven.py
+++ b/src/dags/explosieven.py
@@ -14,6 +14,7 @@ from common import (
     SHARED_DIR,
     MessageOperator,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -45,6 +46,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/fietspaaltjes.py
+++ b/src/dags/fietspaaltjes.py
@@ -2,6 +2,8 @@ import pathlib
 from airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from http_fetch_operator import HttpFetchOperator
 from postgres_files_operator import PostgresFilesOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -23,7 +25,12 @@ sql_path = pathlib.Path(__file__).resolve().parents[0] / "sql"
 # dag_config = Variable.get(dag_id, deserialize_json=True)
 
 
-with DAG(dag_id, default_args=default_args, template_searchpath=["/"]) as dag:
+with DAG(
+     dag_id,
+     default_args=default_args,
+     template_searchpath=["/"],
+     on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
+) as dag:
 
     tmp_dir = f"{SHARED_DIR}/{dag_id}"
 

--- a/src/dags/geluidzones.py
+++ b/src/dags/geluidzones.py
@@ -14,6 +14,7 @@ from common import (
     SHARED_DIR,
     MessageOperator,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -45,6 +46,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/gob.py
+++ b/src/dags/gob.py
@@ -4,6 +4,8 @@ import pathlib
 from typing import Any
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from dynamic_dagrun_operator import TriggerDynamicDagRunOperator
 from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
 from postgres_table_init_operator import PostgresTableInitOperator
@@ -64,6 +66,7 @@ def create_gob_dag(is_first: bool, gob_dataset_id: str, gob_table_id: str) -> DA
         default_args={"owner": owner, **default_args},
         schedule_interval=f"0 {schedule_start_hour} * * *" if is_first else None,
         tags=["gob"],
+        on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
     )
 
     kwargs = dict(

--- a/src/dags/grex.py
+++ b/src/dags/grex.py
@@ -11,6 +11,7 @@ from sqlalchemy.types import Date, Float, Integer, Text
 from common import default_args
 from common.db import get_engine, get_ora_engine
 from common.sql import SQL_CHECK_COUNT, SQL_CHECK_GEO
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import PostgresCheckOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 
@@ -97,6 +98,7 @@ with DAG(
     default_args=default_args,
     description="GrondExploitatie",
     schedule_interval="0 6 * * *",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     load_data = PythonOperator(

--- a/src/dags/hoofdroutes.py
+++ b/src/dags/hoofdroutes.py
@@ -12,6 +12,7 @@ from common.sql import (
     SQL_CHECK_COLNAMES,
     SQL_CHECK_GEO,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from importscripts.import_hoofdroutes import import_hoofdroutes
 from postgres_check_operator import PostgresCheckOperator, PostgresValueCheckOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -22,6 +23,7 @@ dag_id = "hoofdroutes"
 with DAG(
     dag_id,
     default_args=default_args,
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     tmp_dir = f"{SHARED_DIR}/{dag_id}"

--- a/src/dags/hoofdroutes_verkeer.py
+++ b/src/dags/hoofdroutes_verkeer.py
@@ -12,6 +12,7 @@ from airflow.hooks.postgres_hook import PostgresHook
 from common import default_args, SHARED_DIR
 from common.db import get_engine
 from common.http import download_file
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -149,7 +150,11 @@ def _load_geojson(postgres_conn_id):
             hook.run(route.post_process)
 
 
-with DAG(dag_id, default_args=default_args) as dag:
+with DAG(
+     dag_id,
+     default_args=default_args,
+     on_failure_callback=get_contact_point_on_failure_callback(dataset_id="hoofdroutes")
+) as dag:
 
     count_checks = []
     colname_checks = []

--- a/src/dags/horeca_exploitatievergunning.py
+++ b/src/dags/horeca_exploitatievergunning.py
@@ -12,6 +12,7 @@ from sqlalchemy.types import Date, Integer, Text
 from common import default_args
 from common.sql import SQL_CHECK_COUNT, SQL_CHECK_GEO
 from common.db import get_engine, get_ora_engine
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import PostgresCheckOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 
@@ -146,7 +147,7 @@ from DMDATA.HORECA_EXPLOITATIEVERGUNNING_V
                  ALTER TABLE {table_name}
                  RENAME COLUMN STATUS_VERLENG_TIJDELK_TERRAS to STATUS_VERLENGING_TIJDELIJK_TERRAS;                  
              """
-            )      
+            )
 
 
 with DAG(
@@ -154,6 +155,7 @@ with DAG(
     default_args=default_args,
     description="Horeca Exploitatievergunning",
     schedule_interval="0 9 * * *",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id="horeca")
 ) as dag:
 
     load_data = PythonOperator(

--- a/src/dags/huishoudelijkafval.py
+++ b/src/dags/huishoudelijkafval.py
@@ -1,6 +1,8 @@
 from airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from importscripts.import_afvalinzamelingplanning import load_from_dwh
 from swift_load_sql_operator import SwiftLoadSqlOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
@@ -49,6 +51,7 @@ with DAG(
     dag_id,
     default_args={**default_args, **{"owner": owner}},
     description="Huishoudelijkafval objecten, loopafstanden en planning afvalinzamelingvoertuigen",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/milieuzones.py
+++ b/src/dags/milieuzones.py
@@ -5,6 +5,8 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.dummy_operator import DummyOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from ogr2ogr_operator import Ogr2OgrOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
@@ -50,6 +52,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote_string),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/ondergrond.py
+++ b/src/dags/ondergrond.py
@@ -3,6 +3,7 @@ from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
 from swift_operator import SwiftOperator
 from ogr2ogr_operator import Ogr2OgrOperator
@@ -69,6 +70,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/openbareverlichting.py
+++ b/src/dags/openbareverlichting.py
@@ -5,7 +5,7 @@ from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
 
-
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -52,6 +52,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/oplaadpalen.py
+++ b/src/dags/oplaadpalen.py
@@ -1,7 +1,7 @@
 import pathlib
 from airflow import DAG
 
-
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import PostgresCheckOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.hooks.postgres_hook import PostgresHook
@@ -59,6 +59,7 @@ with DAG(
     default_args=vsd_default_args,
     template_searchpath=["/"],
     schedule_interval="@hourly",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     tmp_dir = f"{SHARED_DIR}/{dag_id}"
@@ -110,7 +111,7 @@ with DAG(
         sql=SQL_CHECK_GEO,
         params=dict(tablename=f"{dag_id}_new", geotype="ST_Point"),
     )
-    
+
     # 10. Grant database permissions
     grant_db_permissions = PostgresPermissionsOperator(
         task_id="grants",

--- a/src/dags/overlastgebieden.py
+++ b/src/dags/overlastgebieden.py
@@ -5,6 +5,7 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.dummy_operator import DummyOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -49,6 +50,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/parkeervakken.py
+++ b/src/dags/parkeervakken.py
@@ -13,6 +13,8 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from shapely.geometry import Polygon
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from swift_hook import SwiftHook
 from common import default_args, SHARED_DIR
 from postgres_check_operator import (
@@ -254,7 +256,8 @@ args = default_args.copy()
 with DAG(
     dag_id,
     default_args=args,
-    description="Parkeervakken"    
+    description="Parkeervakken",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     source = pathlib.Path(TMP_DIR)

--- a/src/dags/parkeerzones.py
+++ b/src/dags/parkeerzones.py
@@ -16,6 +16,7 @@ from common import (
     MessageOperator,
     quote_string,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -66,6 +67,7 @@ with DAG(
     description="parkeerzones met en zonder uitzonderingen.",
     default_args=default_args,
     user_defined_filters=dict(quote=quote_string),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/precariobelasting.py
+++ b/src/dags/precariobelasting.py
@@ -8,6 +8,7 @@ from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from swift_operator import SwiftOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
@@ -62,6 +63,7 @@ with DAG(
     dag_id,
     default_args=default_args,
     user_defined_filters=dict(quote=quote_string),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/processenverbaal_verkiezingen.py
+++ b/src/dags/processenverbaal_verkiezingen.py
@@ -4,6 +4,8 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from more_ds.network.url import URL
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from ogr2ogr_operator import Ogr2OgrOperator
@@ -51,6 +53,7 @@ with DAG(
     # every ten minutes the data is refreshed
     schedule_interval="*/10 * * * *",
     catchup=False,
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id="verkiezingen")
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/rdw.py
+++ b/src/dags/rdw.py
@@ -4,6 +4,8 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from common.db import DatabaseEngine
 from environs import Env
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from http_fetch_operator import HttpFetchOperator
 from more_ds.network.url import URL
 from ogr2ogr_operator import Ogr2OgrOperator
@@ -59,6 +61,7 @@ with DAG(
     description=description,
     default_args=default_args,
     user_defined_filters=dict(quote=quote_string),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/reclamebelasting.py
+++ b/src/dags/reclamebelasting.py
@@ -4,6 +4,8 @@ from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from swift_operator import SwiftOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from provenance_rename_operator import ProvenanceRenameOperator
@@ -58,6 +60,7 @@ with DAG(
     description="""Reclamebelastingjaartarieven per belastinggebied voor (reclame)uitingen
     met oppervlakte >= 0,25 m2 en > 10 weken in een jaar zichtbaar zijn.""",
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id="belastingen")
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/referentiekalender.py
+++ b/src/dags/referentiekalender.py
@@ -1,6 +1,8 @@
 from airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from importscripts.import_referentiekalender import load_from_dwh
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from postgres_check_operator import PostgresCheckOperator
@@ -28,6 +30,7 @@ with DAG(
     default_args={**default_args},
     description="""Generieke kalenderreferentie hierarchische gegevens met datum
         als laagste granulariteit.""",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack
@@ -105,7 +108,7 @@ with DAG(
 
 # FLOW
 [
-    slack_at_start 
+    slack_at_start
     >> load_dwh
     >> check_count
     >> provenance_dwh_data

--- a/src/dags/risicozones.py
+++ b/src/dags/risicozones.py
@@ -5,6 +5,8 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.dummy_operator import DummyOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from ogr2ogr_operator import Ogr2OgrOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from swift_operator import SwiftOperator
@@ -62,6 +64,7 @@ with DAG(
     description="risicozones",
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/schiphol.py
+++ b/src/dags/schiphol.py
@@ -5,6 +5,8 @@ from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.postgres_operator import PostgresOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from ogr2ogr_operator import Ogr2OgrOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from postgres_check_operator import COUNT_CHECK, GEO_CHECK, PostgresMultiCheckOperator
@@ -46,6 +48,7 @@ with DAG(
     "maatgevendetoetshoogtes en vogelvrijwaringsgebieden",
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/spoorlijnen.py
+++ b/src/dags/spoorlijnen.py
@@ -5,6 +5,7 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.postgres_operator import PostgresOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -45,6 +46,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/sport.py
+++ b/src/dags/sport.py
@@ -8,6 +8,7 @@ from airflow.operators.python_operator import PythonOperator
 from airflow.operators.dummy_operator import DummyOperator
 from collections import defaultdict
 from common.db import DatabaseEngine
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from ogr2ogr_operator import Ogr2OgrOperator
 from http_fetch_operator import HttpFetchOperator
 from provenance_rename_operator import ProvenanceRenameOperator
@@ -108,6 +109,7 @@ with DAG(
     description="sportfaciliteiten, -objecten en -aanbieders",
     default_args=default_args,
     user_defined_filters=dict(quote=quote_string),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/touringcars.py
+++ b/src/dags/touringcars.py
@@ -15,6 +15,7 @@ from common import (
     SHARED_DIR,
     MessageOperator,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from http_fetch_operator import HttpFetchOperator
 from importscripts.import_touringcars import import_touringcars
 from postgres_check_operator import (
@@ -55,6 +56,7 @@ with DAG(
     dag_id,
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/trm.py
+++ b/src/dags/trm.py
@@ -2,6 +2,8 @@ import pathlib
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import PostgresCheckOperator, PostgresValueCheckOperator
 from postgres_files_operator import PostgresFilesOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -33,6 +35,7 @@ with DAG(
     dag_id,
     default_args=vsd_default_args,
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id="spoorlijnen")
 ) as dag:
 
     extract_zips = []

--- a/src/dags/varen.py
+++ b/src/dags/varen.py
@@ -1,4 +1,6 @@
 from airflow import DAG
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from swift_load_sql_operator import SwiftLoadSqlOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from provenance_drop_from_schema_operator import ProvenanceDropFromSchemaOperator
@@ -20,7 +22,11 @@ dag_id = "varen"
 
 
 owner = "team_ruimte"
-with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
+with DAG(
+     dag_id,
+     default_args={**default_args, **{"owner": owner}},
+     on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
+) as dag:
 
     # 1. Post message on slack
     slack_at_start = MessageOperator(

--- a/src/dags/vastgoed.py
+++ b/src/dags/vastgoed.py
@@ -3,6 +3,7 @@ from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
@@ -36,6 +37,7 @@ with DAG(
     description="verhuurbare eenheden van gemeentelijke vastgoed objecten",
     default_args=default_args,
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/veiligeafstanden.py
+++ b/src/dags/veiligeafstanden.py
@@ -4,6 +4,8 @@ from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from ogr2ogr_operator import Ogr2OgrOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
 from postgres_check_operator import COUNT_CHECK, GEO_CHECK, PostgresMultiCheckOperator
@@ -44,6 +46,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/vergunningen.py
+++ b/src/dags/vergunningen.py
@@ -5,6 +5,7 @@ from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.postgres_operator import PostgresOperator
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_files_operator import PostgresFilesOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 from swift_operator import SwiftOperator
@@ -61,6 +62,7 @@ with DAG(
     default_args=default_args,
     user_defined_filters=dict(quote=quote),
     template_searchpath=["/"],
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post message on slack

--- a/src/dags/verzinkbarepalen.py
+++ b/src/dags/verzinkbarepalen.py
@@ -4,6 +4,7 @@ import operator
 from airflow.models import Variable
 from airflow import DAG
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from ogr2ogr_operator import Ogr2OgrOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from postgres_rename_operator import PostgresTableRenameOperator
@@ -53,6 +54,7 @@ with DAG(
     default_args=default_args,
     template_searchpath=["/"],
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/winkelgebieden.py
+++ b/src/dags/winkelgebieden.py
@@ -14,6 +14,7 @@ from common import (
     SHARED_DIR,
     MessageOperator,
 )
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from postgres_check_operator import (
     PostgresMultiCheckOperator,
     COUNT_CHECK,
@@ -44,6 +45,7 @@ with DAG(
     default_args=default_args,
     template_searchpath=["/"],
     user_defined_filters=dict(quote=quote),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. MESSAGE

--- a/src/dags/wior.py
+++ b/src/dags/wior.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone, tzinfo
 
 from dateutil import tz
 
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from ogr2ogr_operator import Ogr2OgrOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from pgcomparator_cdc_operator import PgComparatorCDCOperator
@@ -98,6 +99,7 @@ with DAG(
     template_searchpath=["/"],
     user_defined_filters=dict(quote=quote_string),
     description="Werken (projecten) in de openbare ruimte.",
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
 ) as dag:
 
     # 1. Post info message on slack

--- a/src/dags/woningbouwplannen.py
+++ b/src/dags/woningbouwplannen.py
@@ -1,5 +1,7 @@
 from airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
+
+from contact_point.callbacks import get_contact_point_on_failure_callback
 from swift_load_sql_operator import SwiftLoadSqlOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from provenance_drop_from_schema_operator import ProvenanceDropFromSchemaOperator
@@ -47,7 +49,11 @@ NM_RENAMES_SQL = """
 """
 
 owner = "team_ruimte"
-with DAG(dag_id, default_args={**default_args, **{"owner": owner}}) as dag:
+with DAG(
+     dag_id,
+     default_args={**default_args, **{"owner": owner}},
+     on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id)
+) as dag:
 
     # 1. Post message on slack
     slack_at_start = MessageOperator(

--- a/src/plugins/contact_point/callbacks.py
+++ b/src/plugins/contact_point/callbacks.py
@@ -1,0 +1,114 @@
+import logging
+from typing import Tuple, cast
+
+from airflow.models.dag import DagStateChangeCallback
+from airflow.models.taskinstance import Context, TaskInstance
+from airflow.settings import TIMEZONE
+from airflow.utils.email import send_email
+from common import DATAPUNT_ENVIRONMENT, ELIGIBLE_EMAIL_ENVIRONMENTS
+from contact_point.models import ContactPoint
+from environs import Env
+from more_ds.network.url import URL
+from pendulum import DateTime
+from schematools.types import DatasetSchema
+from schematools.utils import def_from_url
+
+env = Env()
+SCHEMA_URL = URL(env("SCHEMA_URL"))
+DEFAULT_CONTACT_POINT_NAME = "broneigenaar"
+
+logger = logging.getLogger(__name__)
+
+
+def get_contact_point_on_failure_callback(
+    dataset_id: str, eligible_environments: Tuple[str, ...] = ELIGIBLE_EMAIL_ENVIRONMENTS
+) -> DagStateChangeCallback:
+    """Return a ``contact_point_on_failure_callback`` initialized for a specific dataset.
+
+    Both parameters are implicitly passed into the actual callback by virtue of the closure
+    that Python creates for us.
+
+    The callback, when specified on a :class:`~airflow.models.dag.DAG` or
+    :class:`~airflow.models.baseoperator.BaseOperator` as the value to the argument
+    ``on_failure_callback``, will be invoked when an unhandled exception is raised during the
+    execution of the DAG or operator. It will try to retrieve a contact point for the dataset
+    it was initialized with and, if found, send a email to that contact point with a notification
+    of the failure.
+
+    The email will only be sent if the environment we are running in matches one of the
+    environments specified in ``eligible_environments``
+
+    Args:
+        dataset_id: The dataset we want to retrieve the contact point from
+        eligible_environments: Define the environments in which we are allowed to send email.
+
+    Returns:
+        a ``contact_point_on_failure_callback``
+    """
+
+    def _contact_point_on_failure_callback(context: Context) -> None:
+        logger.info("Import of dataset '%s' failed.", dataset_id)
+
+        ti = cast(TaskInstance, context["ti"])
+        logger.debug("Trying to retrieve contact point.")
+
+        dataset = def_from_url(SCHEMA_URL, DatasetSchema, dataset_id)
+        if "contactPoint" in dataset:
+            cp = dataset["contactPoint"]
+            contact_point = ContactPoint(**cp)
+            logger.debug("Contact point found: '%s'", contact_point)
+        else:
+            contact_point = ContactPoint()
+            logger.debug("Contact point not found!")
+
+        if contact_point.email is None:
+            logger.warning(
+                "No contact point email address was found to sent failure notification to."
+            )
+            return
+
+        name = contact_point.name if contact_point.name else DEFAULT_CONTACT_POINT_NAME
+        execution_date = (
+            cast(DateTime, context["execution_date"])
+            .in_tz(TIMEZONE)
+            .format("dddd D MMMM YYYY, hh:mm:ss", locale="nl")
+        )
+
+        # ``context`` has an ``exception`` key. However, as it turns out, the value stored under
+        # that key is always set to ``None`` if this callback is specified on the DAG (as in our
+        # use case) instead of on the task (as is not our use case). Hence we don't even bother
+        # retrieving it. It does mean, however, that we can't inform the contact point of the
+        # nature of the failure that occurred.
+
+        subject = f"Import mislukt voor dataset: '{dataset_id}'"
+        body = f"""
+            Beste {name},<br>
+            <br>
+            De import van de dataset '{dataset_id}' is mislukt.<br>
+            <br>
+            Tijdstip: '{execution_date}'<br>
+            DAG: '{ti.dag_id}'<br>
+            Taak: '{ti.task_id}' (operator: '{ti.operator}')<br>
+            <br>
+            Neemt contact op met het team Datadiensten op het Slack kanaal #datadiensten om de
+            oorzaak te achterhalen.<br>
+            <br>
+            mvg,<br>
+            Team Datadiensten<br>
+        """
+        logger.debug("Failure notification message:\n%s", body)
+        if DATAPUNT_ENVIRONMENT in eligible_environments:
+            logger.info("Notifying contact point '%s' of import failure by email.", contact_point)
+            send_email((contact_point.email,), subject, html_content=body)
+        else:
+            logger.info(
+                "Not notifying contact point '%s' by email"
+                " as we do not run in an eligible environment."
+                " Current environment: '%s'."
+                " Eligible environment(s): '%s'.",
+                contact_point,
+                DATAPUNT_ENVIRONMENT,
+                ", ".join(eligible_environments),
+            )
+
+    return _contact_point_on_failure_callback

--- a/src/plugins/contact_point/models.py
+++ b/src/plugins/contact_point/models.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ContactPoint:
+    """Represent an Amsterdam Schema ``contactPoint``.
+
+    The Amsterdam Schema defines the ``contactPoint``, but also its attributes, to be entirely
+    optional.
+    """
+
+    name: Optional[str] = None
+    email: Optional[str] = None
+
+    def __str__(self) -> str:
+        """Return human readable string representation.
+
+        We strive for ``"name <email>"``, but it can even be just
+         - an empty string,
+         - only the name
+         - only the email address.
+
+        Returns:
+            Human readable string representation.
+        """
+        name = self.name if self.name else ""
+        email = f"<{self.email}>" if self.email else ""
+        return f"{name} {email}".strip()

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -35,5 +35,5 @@ pyshp == 2.1.0
 cx-Oracle == 7.3.0
 validator-collection == 1.4.1
 clevercsv==0.1.4
-more-ds == 0.0.3
+more-ds == 0.0.4
 pendulum == 2.1.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -308,7 +308,7 @@ mccabe==0.6.1
     # via flake8
 methodtools==0.4.2
     # via amsterdam-schema-tools
-more-ds==0.0.3
+more-ds==0.0.4
     # via -r requirements.in
 more-itertools==8.8.0
     # via flake8-implicit-str-concat


### PR DESCRIPTION
This PR introduce an `on_error_callback` that, when a DAG run fails, can retrieve the `contactPoint` from the associated Amsterdam Schema to find out who to email a failure notification to.

It also introduces tighter pre-commit checks for this project.

When reviewing please pay special attention to commit fa09e55a0bed53b5e553564a6f682c9ef4f2534c The commit explains the why it needs some special care (TL;DR there is no always a direct mapping between `dag_id` and `dataset_id`.)

As usual, probably best reviewed per commit