### PR TITLE
flake8: use extend-ignore instead of ignore.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,7 +19,7 @@ docstring-convention = google
 statistics = True
 select = A, B, C4, D, E, F, G, P, RST, S, T, W, B9, ISC
 doctests = True
-ignore =
+extend-ignore =
     # D100  Missing docstring in public module
     D100,
     # D104  Missing docstring in public package
@@ -34,8 +34,6 @@ ignore =
     F405,
     # E731  Allow lambdas:
     E731,
-    # W503  line break before binary operator (incompatible with black):
-    W503,
     # R102  Allow raise Exception()
     R102
 exclude =


### PR DESCRIPTION
`flake8` has a default ignore list. Reason being that, according to its
maintainer on the podcast https://testandcode.com/156?t=230, PEP8 has
flip flopped on certain style recommendations over the years. So
`flake8` simply adds those to the default ignore list. In addition there
are number of style checks that are each other's opposite. These are
added to the default ignore list as well.

So when specifying your own `ignore` list these default values are
overwritten. Hence it's better to extend the ignore list by means of the
`extend-ignore` option. And that's what I'm doing in this commit.

BTW I'm removing the W503 rule. It's already part of the default ignore
list.