### PR TITLE
Escape literal name when compiling as regular expression

### DIFF
--- a/src/plugins/sqlalchemy_create_object_operator.py
+++ b/src/plugins/sqlalchemy_create_object_operator.py
@@ -106,7 +106,7 @@ class SqlAlchemyCreateObjectOperator(BaseOperator, XComAttrAssignerMixin):
 
         # NB. data_table_name could have been changed because of xcom info
         if isinstance(self.data_table_name, str):
-            self.data_table_name = re.compile(self.data_table_name)
+            self.data_table_name = re.compile(re.escape(self.data_table_name))
         else:
             self.data_table_name = self.data_table_name
 


### PR DESCRIPTION
Spotted this while checking out  #286. We accept a literal name (string) or a regular expression for `SqlAlchemyCreateObjectOperator.data_table_name`. I suppose a valid name is also a valid regexp, but it's easier to catch bugs when it's escaped first.