### PR TITLE
OGR2OGR promote_to_multi fix

### DIFF
--- a/src/dags/bouwstroompunten.py
+++ b/src/dags/bouwstroompunten.py
@@ -121,7 +121,6 @@ with DAG(
         s_srs=None,
         fid="ogc_fid",
         auto_detect_type="YES",
-        promote_to_multi=False,
         mode="PostgreSQL",
         db_conn=db_conn,
     )

--- a/src/dags/bouwstroompunten.py
+++ b/src/dags/bouwstroompunten.py
@@ -121,6 +121,7 @@ with DAG(
         s_srs=None,
         fid="ogc_fid",
         auto_detect_type="YES",
+        promote_to_multi=False,
         mode="PostgreSQL",
         db_conn=db_conn,
     )

--- a/src/dags/overlastgebieden.py
+++ b/src/dags/overlastgebieden.py
@@ -74,7 +74,7 @@ with DAG(
             operation="get",
             create_intermediate_dirs=True,
         )
-        for file in files_to_download.keys()
+        for file in files_to_download
     ]
 
     # 4. Dummy operator acts as an interface between parallel tasks
@@ -96,9 +96,7 @@ with DAG(
             db_conn=db_conn,
             geometry_name="geometry",
             promote_to_multi=True,
-            sql_statement=f"""\"SELECT * FROM OOV_gebieden_totaal
-                                WHERE 1=1 AND TYPE = '{code}'\"
-                                """,  # noqa: S608
+            sql_statement=f"\"SELECT * FROM OOV_gebieden_totaal WHERE 1=1 AND TYPE = '{code}'\"",  # noqa: S608
         )
         for key, code in tables_to_create.items()
     ]

--- a/src/plugins/ogr2ogr_operator.py
+++ b/src/plugins/ogr2ogr_operator.py
@@ -125,21 +125,13 @@ class Ogr2OgrOperator(BaseOperator):
 
         # generic optional parameters
         if self.sql_statement:
-            logger.error(
-                """***********************************************YES1!""",
-            )
             ogr2ogr_cmd.append(f"-sql {self.sql_statement} ")
         if self.promote_to_multi:
-            logger.error(
-                """***********************************************YES2!""",
-            )
             ogr2ogr_cmd.append("-nlt PROMOTE_TO_MULTI ")
 
         # execute cmd string
         try:
             subprocess.run("".join(ogr2ogr_cmd), shell=True, check=True)  # noqa: S602
-            logger.error("******")
-            logger.error("".join(ogr2ogr_cmd))
         except subprocess.CalledProcessError as err:
             logger.error(
                 """Something went wrong, cannot execute subproces.

--- a/src/plugins/ogr2ogr_operator.py
+++ b/src/plugins/ogr2ogr_operator.py
@@ -125,13 +125,21 @@ class Ogr2OgrOperator(BaseOperator):
 
         # generic optional parameters
         if self.sql_statement:
-            ogr2ogr_cmd.append(f"-sql {self.sql_statement}")
+            logger.error(
+                """***********************************************YES1!""",
+            )
+            ogr2ogr_cmd.append(f"-sql {self.sql_statement} ")
         if self.promote_to_multi:
+            logger.error(
+                """***********************************************YES2!""",
+            )
             ogr2ogr_cmd.append("-nlt PROMOTE_TO_MULTI ")
 
         # execute cmd string
         try:
             subprocess.run("".join(ogr2ogr_cmd), shell=True, check=True)  # noqa: S602
+            logger.error("******")
+            logger.error("".join(ogr2ogr_cmd))
         except subprocess.CalledProcessError as err:
             logger.error(
                 """Something went wrong, cannot execute subproces.


### PR DESCRIPTION
The promote_to_multi option was not optional yet. Turn it into an boolean value where de default is set to False (not promoting geometry objects to multigeometry objects).

Currently it was leading to errors in Airflow because it was defaulted to always promote. This lead to geometry check issues.