### PR TITLE
Hotfix: disable checkdags script.

### DIFF
--- a/src/scripts/run.sh
+++ b/src/scripts/run.sh
@@ -92,7 +92,7 @@ airflow variables import vars/vars.json
 # to run the checkscript.
 # Make sure that the the containing shell script (run.sh)
 # stops on errors (set -e).
-python scripts/checkdags.py || exit
+#python scripts/checkdags.py || exit
 
 # sleep infinity
 /usr/local/bin/supervisord --config /usr/local/airflow/etc/supervisord.conf


### PR DESCRIPTION
Service does not come up after new deployment to acceptance. The
checkdags script might be a contributing factor to this issue as it
takes a while to run. This prevents the service to respond to the
deployment health checks in time.

But the real culprit is probably `run.sh` in its entirety. It takes way
too long to execute all those `airflow` commands.