### PR TITLE
stroomstoringen additions

### DIFF
--- a/src/dags/sql/stroomstoringen.py
+++ b/src/dags/sql/stroomstoringen.py
@@ -1,10 +1,25 @@
 from typing import Final
 
-# The data contains epoch times.
+# Before creating the target table based on the schema definition
+# make sure it is dropped if exists.
+DROP_TABLE_IF_EXISTS: Final = """
+DROP TABLE IF EXISTS {{ params.tablename }};
+"""
+
+# Check if table contains source data.
+# If the source does not have data (no electric blackouts present)
+# then the source column `storing_nummer` is not present.
+# In the latter case, this operation will crash. Then in the DAG flow this
+# will trigger a different path to execute.
+CHECK_TABLE: Final = """
+SELECT storing_nummer FROM {{ params.tablename }};
+"""
+
+# The source data contains epoch times.
 # In order to translate it to a timestamp, the data is updated.
 # The dates are stored in millseconds.
-# Unix timestamps measures time with seconds, and not milliseconds (in Postgres too)
-# Therefore the values must be devided by 1000 before converting to timestamp
+# Because Unix timestamps measures time with seconds, and not milliseconds (in Postgres too),
+# the values must be devided by 1000 before converting to timestamp.
 CONVERT_DATE_TIME: Final = """
 ALTER TABLE {{ params.tablename }} ALTER COLUMN storing_datum_gemeld TYPE TIMESTAMP
     WITH TIME zone using TO_TIMESTAMP(storing_datum_gemeld/1000);
@@ -20,5 +35,65 @@ ALTER TABLE {{ params.tablename }} ALTER COLUMN storing_service_update TYPE TIME
     WITH TIME zone using TO_TIMESTAMP(storing_service_update/1000);
 ALTER TABLE {{ params.tablename }} ALTER COLUMN log_date TYPE TIMESTAMP
     WITH TIME zone using TO_TIMESTAMP(log_date/1000);
+COMMIT;
+"""
+
+# Due to the nature of the data, it can happen that there are no electric
+# blackouts present at the current time (polling every day every 10 minutes).
+# In that case a dummy record is added indicating there is no electric blackout.
+# The text NO DATA is projected as a multipolygon (requested by the user).
+NO_DATA_PRESENT_INDICATOR: Final = """
+INSERT INTO {{ params.tablename }} (ID, geometry)
+VALUES (-1, ST_Transform(ST_GeomFromText('MULTIPOLYGON (((
+        4.848844913545913 52.3728446270015,
+        4.8491882362998195 52.35989958374957,
+        4.854338077608413 52.35995200047924,
+        4.85416641623146 52.367237320916075,
+        4.863436130586929 52.35989958374955,
+        4.868500141207046 52.35995200047924,
+        4.868070987764663 52.37294942968427,
+        4.862835315767593 52.37289702837396,
+        4.863178638521499 52.36566505125643,
+        4.853393940035171 52.372897028373934,
+        4.848844913545913 52.3728446270015)),
+        ((4.8717268646075595 52.37288945263481,
+        4.8717268646075595 52.36010167236266,
+        4.885288113386856 52.36010167236266,
+        4.885288113386856 52.37299425521125,
+        4.8717268646075595 52.37288945263481)),
+        ((4.887979062849475 52.366501085785295,
+        4.897248777204943 52.366501085785295,
+        4.89707711582799 52.37331372125051,
+        4.900853666120959 52.37331372125051,
+        4.901196988874865 52.35937289637421,
+        4.887979062849475 52.359477731020846,
+        4.887979062849475 52.366501085785295)),
+        ((4.906690152937365 52.37341852282017,
+        4.910466703230334 52.37352332414115,
+        4.917676481062365 52.35926806147886,
+        4.913728269392443 52.35937289637421,
+        4.91081002598424 52.36671072100576,
+        4.907720121199084 52.36660590351987,
+        4.906518491560412 52.35916322633481,
+        4.90308526402135 52.35916322633481,
+        4.906690152937365 52.37341852282017)),
+        ((4.917565308706964 52.37377017014901,
+        4.934044800894464 52.37377017014901,
+        4.934044800894464 52.37146449652752,
+        4.928723298208917 52.371359690321206,
+        4.929066620962823 52.358885976072585,
+        4.924603425162042 52.35878114002205,
+        4.924775086538995 52.371359690321206,
+        4.917565308706964 52.37115007716251,
+        4.917565308706964 52.37377017014901)),
+        ((4.9390181243731845 52.373832666869966,
+        4.943652981550919 52.37393746720823,
+        4.949317806990372 52.35810979967158,
+        4.94536959532045 52.35821463731483,
+        4.942966336043106 52.365867113500556,
+        4.939361447127091 52.365971932739335,
+        4.936614865095841 52.358004961779635,
+        4.932323330672013 52.35790012363894,
+        4.9390181243731845 52.373832666869966)))',4326), 28992));
 COMMIT;
 """

--- a/src/dags/stroomstoringen.py
+++ b/src/dags/stroomstoringen.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Final
+from typing import Dict, Final
 
 import pendulum
 from airflow import DAG
@@ -22,28 +22,33 @@ from ogr2ogr_operator import Ogr2OgrOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 from postgres_rename_operator import PostgresTableRenameOperator
 from provenance_rename_operator import ProvenanceRenameOperator
-from sql.stroomstoringen import CONVERT_DATE_TIME
+from sql.stroomstoringen import (
+    CHECK_TABLE,
+    CONVERT_DATE_TIME,
+    DROP_TABLE_IF_EXISTS,
+    NO_DATA_PRESENT_INDICATOR,
+)
+from sqlalchemy_create_object_operator import SqlAlchemyCreateObjectOperator
 
-dag_id: str = "stroomstoringen"
-variables: dict = Variable.get("stroomstoringen", deserialize_json=True)
+DAG_ID: Final = "stroomstoringen"
+variables: Dict[str, Dict[str, str]] = Variable.get("stroomstoringen", deserialize_json=True)
 endpoint_url: str = variables["data_endpoints"]["stroomstoringen"]
 
-
 TODAY: Final = pendulum.now(TIMEZONE).format("MM-DD-YYYY")
-TMP_DIR: str = f"{SHARED_DIR}/{dag_id}"
+TMP_DIR: Final = Path(SHARED_DIR) / DAG_ID
 
 db_conn = DatabaseEngine()
 
 
 with DAG(
-    dag_id,
+    DAG_ID,
     description="locaties / gebieden stroomstoringen electra netwerk Liander.",
     default_args=default_args,
     user_defined_filters={"quote": quote_string},
     template_searchpath=["/"],
     schedule_interval="*/10 * * * *",
     catchup=False,
-    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=dag_id),
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=DAG_ID),
 ) as dag:
 
     # 1. Post info message on slack
@@ -51,12 +56,12 @@ with DAG(
         task_id="slack_at_start",
         http_conn_id="slack",
         webhook_token=slack_webhook_token,
-        message=f"Starting {dag_id} ({DATAPUNT_ENVIRONMENT})",
+        message=f"Starting {DAG_ID} ({DATAPUNT_ENVIRONMENT})",
         username="admin",
     )
 
     # 2. Create temp directory to store files
-    mkdir = mk_dir(Path(TMP_DIR))
+    mkdir = mk_dir(TMP_DIR, clean_if_exists=False)
 
     # 3. download the data into temp directorys
     download_data = HttpFetchOperator(
@@ -67,10 +72,10 @@ with DAG(
         output_type="text",
     )
 
-    # 4. Create SQL
+    # 4. Import data
     import_data = Ogr2OgrOperator(
         task_id="import_data",
-        target_table_name=f"{dag_id}_{dag_id}_new",
+        target_table_name=f"{DAG_ID}_{DAG_ID}_new",
         input_file=f"{TMP_DIR}/stroomstoringen.geojson",
         auto_detect_type="YES",
         mode="PostgreSQL",
@@ -80,39 +85,90 @@ with DAG(
         db_conn=db_conn,
     )
 
-    # 5. convert epoch time
+    # 5. Check target table if source data structure is loaded
+    # NOTE: This task has zero retries. It is used to determine
+    # what path to executed based on it's outcome.
+    check_table = PostgresOperator(
+        task_id="check_table",
+        sql=CHECK_TABLE,
+        params={"tablename": f"{DAG_ID}_{DAG_ID}_new"},
+        retries=0,
+    )
+
+    # 6. Drop table if exists
+    # NOTE: This triggers only if upstream task has failed.
+    drop_table = PostgresOperator(
+        task_id="drop_table",
+        sql=DROP_TABLE_IF_EXISTS,
+        params={"tablename": f"{DAG_ID}_{DAG_ID}_new"},
+        trigger_rule="all_failed",
+    )
+
+    # 7. Create the DB target temp table (based on the JSON data schema)
+    # if table not exists yet
+    # this ensures that when the source does not contain any data at a particular
+    # moment (there can be no electric blackout at the current time) the table is still
+    # created and the indication no data is present can be added.
+    create_table = SqlAlchemyCreateObjectOperator(
+        task_id="create_table_based_upon_schema",
+        data_schema_name=DAG_ID,
+        data_table_name=f"{DAG_ID}_{DAG_ID}",
+        db_table_name=f"{DAG_ID}_{DAG_ID}_new",
+        ind_table=True,
+        # when set to false, it doesn't create indexes; only tables
+        ind_extra_index=True,
+    )
+
+    # 8. If source has no data add dummy record (indication no data present)
+    no_data_indicator = PostgresOperator(
+        task_id="no_data_indicator",
+        sql=NO_DATA_PRESENT_INDICATOR,
+        params={"tablename": f"{DAG_ID}_{DAG_ID}_new"},
+    )
+
+    # 9. convert epoch time
+    # NOTE: This triggers only if upstream task has been succesful.
     convert_datetime = PostgresOperator(
         task_id="convert_datetime",
         sql=CONVERT_DATE_TIME,
-        params={"tablename": f"{dag_id}_{dag_id}_new"},
+        params={"tablename": f"{DAG_ID}_{DAG_ID}_new"},
+        trigger_rule="all_success",
     )
 
-    # 6. Rename COLUMNS based on Provenance
+    # 10. Rename COLUMNS based on Provenance
+    # NOTE: This triggers if one of the parent upstream tasks has been succesful.
     provenance_translation = ProvenanceRenameOperator(
         task_id="rename_columns",
-        dataset_name=dag_id,
-        prefix_table_name=f"{dag_id}_",
+        dataset_name=DAG_ID,
+        prefix_table_name=f"{DAG_ID}_",
         postfix_table_name="_new",
         rename_indexes=False,
         pg_schema="public",
+        trigger_rule="one_success",
     )
 
-    # 7. Rename TABLE
+    # 11. Rename TABLE
     rename_table = PostgresTableRenameOperator(
         task_id="rename_table",
-        old_table_name=f"{dag_id}_{dag_id}_new",
-        new_table_name=f"{dag_id}_{dag_id}",
+        old_table_name=f"{DAG_ID}_{DAG_ID}_new",
+        new_table_name=f"{DAG_ID}_{DAG_ID}",
     )
 
-    # 8. Grant database permissions
-    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=dag_id)
+    # 12. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=DAG_ID)
+
+
+# FLOW
+slack_at_start >> mkdir >> download_data >> import_data >> check_table
+
+# Based on outcome check_table
+# path 1: Case: Source has no data, so table is created and dummy record is inserted
+[check_table >> drop_table >> create_table >> no_data_indicator]
+# path 2: Case: Source has data, so processed accordingly
+[check_table >> convert_datetime]
 
 (
-    slack_at_start
-    >> mkdir
-    >> download_data
-    >> import_data
-    >> convert_datetime
+    [no_data_indicator, convert_datetime]
     >> provenance_translation
     >> rename_table
     >> grant_db_permissions

--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -344,11 +344,11 @@ rdw:
     carrosserie: /vezc-m2t6.csv
 stroomstoringen:
   data_endpoints:
-    stroomstoringen: "/v6W5HAVrpgSg3vts/ArcGIS/rest/services/IStoringen_Productie_V7/FeatureServer/0/query?\
-      where=STORING_DATUM_GEMELD+%3E%3D+%27{today}%27+AND+lower%28STORING_GETROFFEN_PLAATSEN%29+%3D+%27amsterdam%27\
-      &objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&resultType=none\
-      &distance=0.0&units=esriSRUnit_Meter&returnGeodetic=false&outFields=*&returnGeometry=true&returnCentroid=false&featureEncoding=esriDefault\
-      &multipatchOption=xyFootprint&maxAllowableOffset=&geometryPrecision=&outSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false\
-      &returnUniqueIdsOnly=false&returnCountOnly=false&returnExtentOnly=false&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false\
-      &orderByFields=&groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false\
-      &returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pgeojson&token="
+    stroomstoringen: "/v6W5HAVrpgSg3vts/ArcGIS/rest/services/IStoringen_Productie_V7/FeatureServer/0/query?where=STORING_DATUM_GEMELD+>%3D+%27{today}%27+AND+\
+                    lower(STORING_GETROFFEN_PLAATSEN)+in+(%27amsterdam%27,%27weesp%27)&objectIds=&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&\
+                    patialRel=esriSpatialRelIntersects&resultType=none&distance=0.0&units=esriSRUnit_Meter&returnGeodetic=false&outFields=*&\
+                    returnGeometry=true&returnCentroid=false&featureEncoding=esriDefault&multipatchOption=xyFootprint&maxAllowableOffset=&\
+                    geometryPrecision=&outSR=&datumTransformation=&applyVCSProjection=false&returnIdsOnly=false&returnUniqueIdsOnly=false&\
+                    returnCountOnly=false&returnExtentOnly=false&returnQueryGeometry=false&returnDistinctValues=false&cacheHint=false&orderByFields=&\
+                    groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&returnZ=false&returnM=false&\
+                    returnExceededLimitFeatures=true&quantizationParameters=&sqlFormat=none&f=pgeojson&token="


### PR DESCRIPTION
- Weesp is added to the source query request.
- Source data is imported by ogr2ogr. If the source result set is empty (what can happen if there are no electic blackouts), it will create an target table missing some key columns. If so, the table is created by using the schema definition instead and a dummy record is inserted indication no data (on request).

The DAG uses the trigger rules concept provided by Airflow (trough inheritance of the baseoperator). The steps can therefore be triggered according to the set rule e.g. all_success or one_success etc.