### PR TITLE
Fix issue with psycopg2.sql.Identifier

### DIFF
--- a/src/plugins/provenance_rename_operator.py
+++ b/src/plugins/provenance_rename_operator.py
@@ -159,6 +159,7 @@ class ProvenanceRenameOperator(BaseOperator):
         """
         dataset = schema_def_from_url(SCHEMA_URL, self.dataset_name)
         pg_hook = PostgresHook(postgres_conn_id=self.postgres_conn_id)
+        connection = pg_hook.get_conn()
         sqls = []
         existing_tables_lookup = self._get_existing_tables(
             pg_hook, dataset.tables, pg_schema=self.pg_schema
@@ -186,8 +187,12 @@ class ProvenanceRenameOperator(BaseOperator):
                                 ALTER INDEX {old_index_name}
                                     RENAME TO {new_index_name}
                             """.format(
-                                    old_index_name=sql.Identifier(self.pg_schema, index_name),
-                                    new_index_name=sql.Identifier(new_index_name),
+                                    old_index_name=sql.Identifier(
+                                        self.pg_schema, index_name
+                                    ).as_string(connection),
+                                    new_index_name=sql.Identifier(new_index_name).as_string(
+                                        connection
+                                    ),
                                 )
                             )
                         )
@@ -208,9 +213,13 @@ class ProvenanceRenameOperator(BaseOperator):
                                 ALTER TABLE {table_name}
                                     RENAME COLUMN {provenance} TO {snaked_field_name}
                             """.format(
-                                    table_name=sql.Identifier(self.pg_schema, snaked_tablename),
-                                    provenance=sql.Identifier(provenance),
-                                    snaked_field_name=sql.Identifier(snaked_field_name),
+                                    table_name=sql.Identifier(
+                                        self.pg_schema, snaked_tablename
+                                    ).as_string(connection),
+                                    provenance=sql.Identifier(provenance).as_string(connection),
+                                    snaked_field_name=sql.Identifier(snaked_field_name).as_string(
+                                        connection
+                                    ),
                                 )
                             )
                         )
@@ -223,8 +232,12 @@ class ProvenanceRenameOperator(BaseOperator):
                         ALTER TABLE IF EXISTS {old_table_name}
                             RENAME TO {new_table_name}
                     """.format(
-                            old_table_name=sql.Identifier(self.pg_schema, snaked_tablename),
-                            new_table_name=sql.Identifier(to_snake_case(table.id)),
+                            old_table_name=sql.Identifier(
+                                self.pg_schema, snaked_tablename
+                            ).as_string(connection),
+                            new_table_name=sql.Identifier(to_snake_case(table.id)).as_string(
+                                connection
+                            ),
                         )
                     )
                 )


### PR DESCRIPTION
When Identifier is not used immediately,
but passed on to `PostgresHook.run`,
it should be stringified explicitly with the
`as_string` method.