### PR TITLE
bouwstroompunten fix

### DIFF
--- a/src/plugins/http_fetch_operator.py
+++ b/src/plugins/http_fetch_operator.py
@@ -7,6 +7,7 @@ from airflow.exceptions import AirflowFailException
 from airflow.hooks.http_hook import HttpHook
 from airflow.models import XCOM_RETURN_KEY
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.taskinstance import Context
 from airflow.utils.decorators import apply_defaults
 
 
@@ -23,7 +24,7 @@ class HttpFetchOperator(BaseOperator):
         "headers",
     ]
 
-    @apply_defaults
+    @apply_defaults  # type: ignore[misc]
     def __init__(
         self,
         endpoint: str,
@@ -80,7 +81,7 @@ class HttpFetchOperator(BaseOperator):
 
         super().__init__(*args, **kwargs)
 
-    def execute(self, context: Dict) -> None:  # noqa: C901
+    def execute(self, context: Context) -> None:  # noqa: C901
         """Main execution function.
 
         Args:

--- a/src/plugins/ogr2ogr_operator.py
+++ b/src/plugins/ogr2ogr_operator.py
@@ -116,7 +116,9 @@ class Ogr2OgrOperator(BaseOperator):
             ogr2ogr_cmd.extend(["-nln", self.target_table_name, "-overwrite"])
 
         # generic parameters for all options
-        ogr2ogr_cmd.extend(["-s_srs", self.s_srs if self.s_srs else "", "-t_srs", self.t_srs])
+        if self.s_srs:
+            ogr2ogr_cmd.extend(["-s_srs", self.s_srs])
+        ogr2ogr_cmd.extend(["-t_srs", self.t_srs])
         ogr2ogr_cmd.extend(["-lco", f"FID={self.fid}"])
         ogr2ogr_cmd.extend(["-oo", f"AUTODETECT_TYPE={self.auto_detect_type}"])
         ogr2ogr_cmd.extend(["-lco", f"GEOMETRY_NAME={self.geometry_name}"])
@@ -134,8 +136,9 @@ class Ogr2OgrOperator(BaseOperator):
             subprocess.run(ogr2ogr_cmd, check=True)  # noqa: S603
         except subprocess.CalledProcessError as err:
             logger.error(
-                """Something went wrong, cannot execute subproces.
-              Please check the ogr2ogr cmd %s
+                """Something went wrong..., cannot execute subproces.
+              Please check the ogr2ogr cmd %s. Error: %s
             """,
+                ogr2ogr_cmd,
                 err.output,
             )


### PR DESCRIPTION
The bouwstroompunten uses a HttpFetchOperator to call an API to retrieve source data.For using the API a API token is needed. This token was added to the header. By adding a get_token() within the header definition.

However during 'compile' (when importing the dags) the get_token() was evaluated. Resulting an a error message because the parameters used are not yet loaded.

To prevent from evaluting at compile time (instead of only at run time) the output of get_token() is now passed as a xcom variable. Based on the same logic as BBGA for consistency.