### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Airflow setup for Dataservices, running in a Docker container.
 
 # Requirements
 
-    Python 3.5 - 3.7
+    Python >= 3.8
 
     python3 -m venv .venv
     source .venv/bin/activate
@@ -124,7 +124,7 @@ is generated from a yaml file in `vars/vars.yaml`.
 In a running containers, the following commands can update the variables:
 
     python scripts/mkvars.py
-    airflow variables -i vars/vars.json
+    airflow variables install vars/vars.json
 
 # Connections
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ is generated from a yaml file in `vars/vars.yaml`.
 In a running containers, the following commands can update the variables:
 
     python scripts/mkvars.py
-    airflow variables install vars/vars.json
+    airflow variables import vars/vars.json
 
 # Connections
 


### PR DESCRIPTION
2 minor changes in the README file:

- Python 3.8 is required for some packages, so the python 3.5 - 3.7 requirement had to be changed
- Airflow command to update variables is changed in newer versions of Airflow