### PR TITLE
[FIX] postgres_table_copy_operator - column order

### DIFF
--- a/src/dags/anpr.py
+++ b/src/dags/anpr.py
@@ -122,6 +122,7 @@ with DAG(
 
     create_temp_table = PostgresTableCopyOperator(
         task_id="create_temp_table",
+        dataset_name=DAG_ID,
         source_table_name=TABLE_ID,
         target_table_name=f"{TABLE_ID}_temp",
         # Only copy table definitions. Don't do anything else.

--- a/src/dags/basiskaart.py
+++ b/src/dags/basiskaart.py
@@ -141,6 +141,7 @@ def table_task_group(table: Table) -> DAG:
 
         create_temp_table = PostgresTableCopyOperator(
             task_id=f"create_temp_table_{table.tmp_id}",
+            dataset_name=DAG_ID,
             source_table_name=table.id,
             target_table_name=table.tmp_id,
             # Only copy table definitions. Don't do anything else.

--- a/src/dags/bbga.py
+++ b/src/dags/bbga.py
@@ -148,7 +148,6 @@ with DAG(
     rename_tables = [
         PostgresTableRenameOperator(
             task_id=f"rename_tables_for_{table}",
-            dataset_name=DAG_ID,
             new_table_name=table,
             old_table_name=f"{TMP_TABLE_PREFIX}{table}",
             cascade=True,

--- a/src/dags/bbga.py
+++ b/src/dags/bbga.py
@@ -148,6 +148,7 @@ with DAG(
     rename_tables = [
         PostgresTableRenameOperator(
             task_id=f"rename_tables_for_{table}",
+            dataset_name=DAG_ID,
             new_table_name=table,
             old_table_name=f"{TMP_TABLE_PREFIX}{table}",
             cascade=True,

--- a/src/dags/bedrijveninvesteringszone.py
+++ b/src/dags/bedrijveninvesteringszone.py
@@ -42,7 +42,7 @@ TMP_TABLE_POSTFIX: Final = "_new"
 
 with DAG(
     dag_id,
-    description="tariefen, locaties en overige contextuele gegevens over bedrijveninvesteringszones.",
+    description="tariefen, locaties en overige context bedrijveninvesteringszones.",
     default_args=default_args,
     user_defined_filters={"quote": quote_string},
     template_searchpath=["/"],
@@ -117,6 +117,7 @@ with DAG(
 
     create_temp_table = PostgresTableCopyOperator(
         task_id="create_temp_table",
+        dataset_name=dag_id,
         source_table_name=TABLE_ID,
         target_table_name=f"{TABLE_ID}{TMP_TABLE_POSTFIX}",
         drop_target_if_unequal=True,
@@ -133,14 +134,14 @@ with DAG(
     update_table = PostgresOperator(
         task_id="update_target_table",
         sql=UPDATE_TABLE,
-        params=dict(tablename=f"{dag_id}_{dag_id}_new"),
+        params={"tablename": f"{dag_id}_{dag_id}_new"},
     )
 
     count_checks.append(
         COUNT_CHECK.make_check(
             check_id="count_check",
             pass_value=50,
-            params=dict(table_name=f"{dag_id}_{dag_id}_new "),
+            params={"table_name": f"{dag_id}_{dag_id}_new "},
             result_checker=operator.ge,
         )
     )
@@ -148,10 +149,10 @@ with DAG(
     geo_checks.append(
         GEO_CHECK.make_check(
             check_id="geo_check",
-            params=dict(
-                table_name=f"{dag_id}_{dag_id}_new",
-                geotype=["POLYGON"],
-            ),
+            params={
+                "table_name": f"{dag_id}_{dag_id}_new",
+                "geotype": ["POLYGON"],
+            },
             pass_value=1,
         )
     )

--- a/src/dags/cmsa.py
+++ b/src/dags/cmsa.py
@@ -126,6 +126,7 @@ with DAG(
     postgres_create_tables_like = [
         PostgresTableCopyOperator(
             task_id=f"postgres_create_tables_like_{table}",
+            dataset_name=DAG_ID,
             source_table_name=table,
             target_table_name=f"{TMP_TABLE_PREFIX}{table}",
             # Only copy table definitions. Don't do anything else.

--- a/src/dags/crowdmonitor.py
+++ b/src/dags/crowdmonitor.py
@@ -183,6 +183,7 @@ with DAG(
 
     create_temp_table = PostgresTableCopyOperator(
         task_id="create_temp_table",
+        dataset_name=DAG_ID,
         source_table_name=TABLE_ID,
         target_table_name=f"{TABLE_ID}{TMP_TABLE_POSTFIX}",
         # Only copy table definitions. Don't do anything else.

--- a/src/dags/deelmobiliteit.py
+++ b/src/dags/deelmobiliteit.py
@@ -208,6 +208,7 @@ with DAG(
     change_data_capture = [
         PostgresTableCopyOperator(
             task_id=f"change_data_capture_{resource}",
+            dataset_name=dag_id,
             source_table_name=f"{dag_id}_{resource}_new",
             target_table_name=f"{dag_id}_{resource}",
             drop_target_if_unequal=True,

--- a/src/dags/fietspaaltjes.py
+++ b/src/dags/fietspaaltjes.py
@@ -73,6 +73,7 @@ with DAG(
 
     postgres_create_tables_like = PostgresTableCopyOperator(
         task_id=f"postgres_create_tables_like_{TABLE}",
+        dataset_name=DAG_ID,
         source_table_name=TABLE,
         target_table_name=f"{TMP_TABLE_PREFIX}{TABLE}",
         # Only copy table definitions. Don't do anything else.

--- a/src/dags/financien_grootboek.py
+++ b/src/dags/financien_grootboek.py
@@ -74,6 +74,7 @@ with DAG(
     # 6. Check for changes to merge in target table by using CDC
     change_data_capture = PostgresTableCopyOperator(
         task_id="change_data_capture",
+        dataset_name=dag_id,
         source_table_name=f"{dag_id}_new",
         target_table_name=dag_id,
         drop_target_if_unequal=True,

--- a/src/dags/gob.py
+++ b/src/dags/gob.py
@@ -129,6 +129,7 @@ def create_gob_dag(is_first: bool, gob_dataset_id: str, gob_table_id: str) -> DA
         # 5. truncate target table and insert data from temp table
         copy_table = PostgresTableCopyOperator(
             task_id=f"copy_{dataset_table_id}",
+            dataset_name=None,
             source_table_name=None,
             target_table_name=None,
             drop_target_if_unequal=True,

--- a/src/dags/huishoudelijkafval.py
+++ b/src/dags/huishoudelijkafval.py
@@ -143,6 +143,7 @@ with DAG(
     # Check for changes to merge in target table by using CDC
     change_data_capture = PostgresTableCopyOperator(
         task_id="change_data_capture",
+        dataset_name=dag_id,
         source_table_name=f"{dag_id}_{to_snake_case(tables['dwh_stadsdelen'])}_new",
         target_table_name=f"{dag_id}_{to_snake_case(tables['dwh_stadsdelen'])}",
         drop_target_if_unequal=True,

--- a/src/dags/ondergrond.py
+++ b/src/dags/ondergrond.py
@@ -194,6 +194,7 @@ with DAG(
     change_data_capture = [
         PostgresTableCopyOperator(
             task_id=f"change_data_capture_{table_name}",
+            dataset_name=dag_id,
             source_table_name=f"{dag_id}_{table_name}_new",
             target_table_name=f"{dag_id}_{table_name}",
             drop_target_if_unequal=True,

--- a/src/dags/processenverbaal_verkiezingen.py
+++ b/src/dags/processenverbaal_verkiezingen.py
@@ -133,6 +133,7 @@ with DAG(
     # 10. Check for changes to merge in target table
     change_data_capture = PostgresTableCopyOperator(
         task_id="change_data_capture",
+        dataset_name=schema_name,
         source_table_name=f"{schema_name}_{table_name}_new",
         target_table_name=f"{schema_name}_{table_name}",
         drop_target_if_unequal=True,

--- a/src/dags/reclamebelasting.py
+++ b/src/dags/reclamebelasting.py
@@ -152,6 +152,7 @@ with DAG(
     # 9. Check for changes to merge in target table
     change_data_capture = PostgresTableCopyOperator(
         task_id="change_data_capture",
+        dataset_name=schema_name,
         source_table_name=f"{schema_name}_{table_name}_new",
         target_table_name=f"{schema_name}_{table_name}",
         drop_target_if_unequal=True,

--- a/src/dags/referentiekalender.py
+++ b/src/dags/referentiekalender.py
@@ -73,6 +73,7 @@ with DAG(
     # Check for changes to merge in target table by using CDC
     change_data_capture = PostgresTableCopyOperator(
         task_id="change_data_capture",
+        dataset_name=dag_id,
         source_table_name=f"{dag_id}_datum_new",
         target_table_name=f"{dag_id}_datum",
         drop_target_if_unequal=True,

--- a/src/dags/risicozones.py
+++ b/src/dags/risicozones.py
@@ -287,6 +287,7 @@ with DAG(
     change_data_capture = [
         PostgresTableCopyOperator(
             task_id=f"change_data_capture_{table_name}",
+            dataset_name=dag_id,
             source_table_name=f"{dag_id}_{table_name}_new",
             target_table_name=f"{dag_id}_{table_name}",
         )

--- a/src/dags/schiphol.py
+++ b/src/dags/schiphol.py
@@ -203,6 +203,7 @@ with DAG(
     change_data_capture = [
         PostgresTableCopyOperator(
             task_id=f"change_data_capture_{key}",
+            dataset_name=dag_id,
             source_table_name=f"{dag_id}_{key}_new",
             target_table_name=f"{dag_id}_{key}",
             drop_target_if_unequal=True,

--- a/src/dags/sport.py
+++ b/src/dags/sport.py
@@ -308,6 +308,7 @@ with DAG(
     change_data_capture = [
         PostgresTableCopyOperator(
             task_id=f"change_data_capture_{resource}",
+            dataset_name=dag_id,
             source_table_name=f"{dag_id}_{resource}_new",
             target_table_name=f"{dag_id}_{resource}",
             drop_target_if_unequal=True,

--- a/src/dags/veiligeafstanden.py
+++ b/src/dags/veiligeafstanden.py
@@ -196,6 +196,7 @@ with DAG(
     change_data_capture = [
         PostgresTableCopyOperator(
             task_id=f"change_data_capture_{key}",
+            dataset_name=dag_id,
             source_table_name=f"{dag_id}_{key}_new",
             target_table_name=f"{dag_id}_{key}",
             drop_target_if_unequal=True,

--- a/src/dags/vergunningen.py
+++ b/src/dags/vergunningen.py
@@ -172,6 +172,7 @@ with DAG(
     change_data_capture = [
         PostgresTableCopyOperator(
             task_id=f"change_data_capture_{target_name}",
+            dataset_name=dag_id,
             source_table_name=f"{dag_id}_{target_name}_new",
             target_table_name=f"{dag_id}_{target_name}",
             drop_target_if_unequal=True,

--- a/src/dags/wior.py
+++ b/src/dags/wior.py
@@ -225,6 +225,7 @@ with DAG(
     # 14. Check for changes to merge in target table
     change_data_capture = PostgresTableCopyOperator(
         task_id="change_data_capture",
+        dataset_name=dag_id,
         source_table_name=f"{dag_id}_{dag_id}_new",
         target_table_name=f"{dag_id}_{dag_id}",
         drop_target_if_unequal=True,


### PR DESCRIPTION
Some DAG''s crashed due to a mismatched datatype when using the "postgres_table_copy_operator". 

The reason is that the operator made the assumption that the column order of the target and the source table during a INSERT SQL statement are identical. 
However this does not is always the case now and maybe in the (near) future also. To prevent a mismatch error the columns are added into the INSERT explicitly so data can get inserted with the correct mapping despite column order.