### PR TITLE
swiftoperator explicit connection to VSD objectstore

### DIFF
--- a/src/dags/asbest.py
+++ b/src/dags/asbest.py
@@ -51,6 +51,7 @@ with DAG(
 
     fetch_zip = SwiftOperator(
         task_id="fetch_zip",
+        swift_conn_id="SWIFT_DEFAULT",
         container=dag_id,
         object_id=zip_file,
         output_path=f"{tmp_dir}/{zip_file}",

--- a/src/dags/bedrijveninvesteringszone.py
+++ b/src/dags/bedrijveninvesteringszone.py
@@ -62,8 +62,7 @@ with DAG(
     download_data = [
         SwiftOperator(
             task_id=f"download_{file}",
-            # if conn is ommitted, it defaults to Objecstore Various Small Datasets
-            # swift_conn_id="SWIFT_DEFAULT",
+            swift_conn_id="SWIFT_DEFAULT",
             container="bedrijveninvesteringszones",
             object_id=str(file),
             output_path=f"{tmp_dir}/{file}",

--- a/src/dags/cmsa.py
+++ b/src/dags/cmsa.py
@@ -62,8 +62,7 @@ with DAG(
     fetch_files = [
         SwiftOperator(
             task_id=f"download_{file}",
-            # if conn is omitted, it defaults to Objecstore Various Small Datasets
-            # swift_conn_id="SWIFT_DEFAULT",
+            swift_conn_id="SWIFT_DEFAULT",
             container="cmsa",
             object_id=file,
             output_path=TMP_DIR / file,

--- a/src/dags/covid_19.py
+++ b/src/dags/covid_19.py
@@ -65,8 +65,7 @@ with DAG(
     download_data = [
         SwiftOperator(
             task_id=f"download_{file}",
-            # Default swift = Various Small Datasets objectstore
-            # swift_conn_id="SWIFT_DEFAULT",
+            swift_conn_id="SWIFT_DEFAULT",
             container="covid19",
             object_id=file,
             output_path=f"{tmp_dir}/{file}",

--- a/src/dags/milieuzones.py
+++ b/src/dags/milieuzones.py
@@ -63,8 +63,7 @@ with DAG(
     download_data = [
         SwiftOperator(
             task_id=f"download_{file}",
-            # Default swift = Various Small Datasets objectstore
-            # swift_conn_id="SWIFT_DEFAULT",
+            swift_conn_id="SWIFT_DEFAULT",
             container="milieuzones",
             object_id=file,
             output_path=f"{tmp_dir}/{file}",

--- a/src/dags/parkeerzones.py
+++ b/src/dags/parkeerzones.py
@@ -80,8 +80,7 @@ with DAG(
     # 3. Download data
     download_data = SwiftOperator(
         task_id="download_file",
-        # Default swift = Various Small Datasets objectstore
-        # swift_conn_id="SWIFT_DEFAULT",
+        swift_conn_id="SWIFT_DEFAULT",
         container=dag_id,
         object_id=file_to_download,
         output_path=f"{tmp_dir}/{file_to_download}",

--- a/src/dags/reclamebelasting.py
+++ b/src/dags/reclamebelasting.py
@@ -68,8 +68,7 @@ with DAG(
     # 3. Download data
     download_data = SwiftOperator(
         task_id=f"download_{zip_file}",
-        # Default swift == Various Small Datasets objectstore
-        # swift_conn_id="SWIFT_DEFAULT",
+        swift_conn_id="SWIFT_DEFAULT",
         container="reclame",
         object_id=zip_file,
         output_path=f"{tmp_dir}/{zip_file}",

--- a/src/dags/spoorlijnen.py
+++ b/src/dags/spoorlijnen.py
@@ -61,8 +61,7 @@ with DAG(
     download_data = [
         SwiftOperator(
             task_id=f"download_{file}",
-            # if conn is ommitted, it defaults to Objecstore Various Small Datasets
-            # swift_conn_id="SWIFT_DEFAULT",
+            swift_conn_id="SWIFT_DEFAULT",
             container="spoorlijnen",
             object_id=str(file),
             output_path=f"{TMP_PATH}/{file}",

--- a/src/dags/vastgoed.py
+++ b/src/dags/vastgoed.py
@@ -51,8 +51,7 @@ with DAG(
     # 3. Download data
     download_data = SwiftOperator(
         task_id=f"download_{files_to_download[0]}",
-        # when swift_conn_id is ommitted then the default connection will be the VSD objectstore
-        # swift_conn_id="SWIFT_DEFAULT",
+        swift_conn_id="SWIFT_DEFAULT",
         container="vastgoed",
         object_id=f"{files_to_download[0]}",
         output_path=f"{tmp_dir}/{files_to_download[0]}",

--- a/src/dags/vergunningen.py
+++ b/src/dags/vergunningen.py
@@ -67,7 +67,7 @@ with DAG(
     download_data = [
         SwiftOperator(
             task_id=f"download_{file}",
-            # swift_conn_id default when ommited is the Various Small Datasets objectstore
+            swift_conn_id="SWIFT_DEFAULT",
             container="bed_and_breakfast",
             object_id=f"{DATAPUNT_ENVIRONMENT}/{file}",
             output_path=f"{tmp_dir}/{file}",


### PR DESCRIPTION
In some DAG''s the swiftoperator is used to download data from the VSD objectstore. The parameter `swift_conn_id` is in many cases omitted. Because with the parameter it defaults to the VSD objectstore. However this default swift (objectstore) connection is not using the baseoperator.get_connection(). This has a drawback on using KeyVault on the Airflow instance on AKS. Basicly KeyVault is not consulted. When ommitted it will use the swift API that will look for OS_* env vars. The Airflow on AKS based on a HELM installation is expecting the Airflow naming conventions for env vars. Hence, that would be AIRFLOW_CONN_*

To solve this, every DAG should always explicitly add swift_id as the `swift_conn_id`. Then the Airflow native baseoperator.get_connection() will be used.