### PR TITLE
Modified branch selector in stroomstoringen DAG

### DIFF
--- a/src/dags/importscripts/import_stroomstoringen.py
+++ b/src/dags/importscripts/import_stroomstoringen.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+
+def _pick_branch(file: str) -> str:
+    """Select branch to be executed based on the amount of current power failures.
+
+    Args:
+        file: path to .geojson file containing info o power failures
+    Returns:
+        string containing name of desired branch
+    """
+    # Read .geojson file
+    df = pd.read_json(file)
+
+    # Check df on amount of power failures
+    if len(df) >= 1:
+        return "convert_datetime"
+    else:
+        return "drop_table"

--- a/src/dags/sql/stroomstoringen.py
+++ b/src/dags/sql/stroomstoringen.py
@@ -6,15 +6,6 @@ DROP_TABLE_IF_EXISTS: Final = """
 DROP TABLE IF EXISTS {{ params.tablename }};
 """
 
-# Check if table contains source data.
-# If the source does not have data (no electric blackouts present)
-# then the source column `storing_nummer` is not present.
-# In the latter case, this operation will crash. Then in the DAG flow this
-# will trigger a different path to execute.
-CHECK_TABLE: Final = """
-SELECT storing_nummer FROM {{ params.tablename }};
-"""
-
 # The source data contains epoch times.
 # In order to translate it to a timestamp, the data is updated.
 # The dates are stored in millseconds.

--- a/src/dags/stroomstoringen.py
+++ b/src/dags/stroomstoringen.py
@@ -59,7 +59,7 @@ with DAG(
     # 2. Create temp directory to store files
     mkdir = mk_dir(TMP_DIR, clean_if_exists=False)
 
-    # 3. download the data into temp directoys
+    # 3. download the data into temp directories
     download_data = HttpFetchOperator(
         task_id="download",
         endpoint=endpoint_url.format(today=TODAY),


### PR DESCRIPTION
Previously, the path in the DAG was chosen based on the success/failure of the 'check_table' PostgresOperator. This worked, but in case of failure of the check_table operator, a failure message was shown in the slack group. This was confusing. I replaced this PostgresOperator with a BranchPythonOperator that checks if the retrieved .geojson file contains data on power failures. Based on the number of power failures it defines the wanted path:
1.  1 or more power failures -> modify and store data
2.  no power failures -> create dummy data 