### PR TITLE
bedrijveninvesteringszones fix

### DIFF
--- a/src/dags/importscripts/convert_bedrijveninvesteringszones_data.py
+++ b/src/dags/importscripts/convert_bedrijveninvesteringszones_data.py
@@ -3,12 +3,11 @@ import re
 
 import pandas
 
-
 def convert_biz_data(table_name, sql_shape_file, xlsx_file, output_file):
 
     try:
         # Read Excel sheet in dataframe df
-        df = pandas.read_excel(xlsx_file)
+        df = pandas.read_excel(xlsx_file, engine="openpyxl")
 
         # Read SQL data  in shape_map dictionary
         with open(sql_shape_file) as fd:

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -38,6 +38,7 @@ cx-Oracle == 8.2.1
 validator-collection == 1.4.1
 clevercsv==0.1.4
 more-ds == 0.0.4
+openpyxl==3.0.8
 pendulum == 2.1.2
 paramiko==2.7.2
 pysftp==0.2.9

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -148,6 +148,8 @@ email-validator==1.1.2
     # via flask-appbuilder
 environs==9.3.3
     # via -r requirements.in
+et-xmlfile==1.1.0
+    # via openpyxl
 flake8==3.9.2
     # via
     #   -r requirements.in
@@ -352,6 +354,8 @@ openapi-schema-validator==0.1.4
     # via openapi-spec-validator
 openapi-spec-validator==0.3.0
     # via connexion
+openpyxl==3.0.8
+    # via -r requirements.in
 ordered-set==4.0.2
     # via deepdiff
 os-service-types==1.7.0


### PR DESCRIPTION
The error occurs when pandas is used in python3.9+, cause the the code:
xml.etree.ElementTree.Element.getiterator() has been removed.

A workaround is to utilize the openpyxl engine to read the excel files. So, adding openpyxl to the requirements and changing pd.read_excel('file.xlsx') to pd.read_excel('file.xlsx', engine='openpyxl') solved the issue. 