### PR TITLE
Removed API restriction to show all data

### DIFF
--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -63,7 +63,7 @@ winkelgebieden:
 bouwstroompunten:
   data_endpoints:
     auth: auth/local/
-    data: power-stations?city=Amsterdam
+    data: power-stations?city=Amsterdam&_limit=-1
 precariobelasting:
   data_endpoints:
     bedrijfsvaartuigen: dcatd/datasets/aUBH75WzCsTcYQ/purls/3


### PR DESCRIPTION
The stroompunten source API was not fully showing all data with a single API call. By using the _limit=-1 variable the data can be fully procesessed. Due to this output limit not all stroompunten where visible at data.amsterdam.nl.