### PR TITLE
Sport openbareruimtes new endpoint

### DIFF
--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -168,7 +168,7 @@ sport:
       sportpark: dcatd/datasets/mdp9l38vc9omBQ/purls/5
   data_endpoints:
     geojson:
-      openbaresportplek: open_geodata/geojson.php?KAARTLAAG=SPORT_OPENBAAR&THEMA=sport
+      openbaresportplek: open_geodata/geojson_latlng.php?KAARTLAAG=SPORT_OPENBAAR&THEMA=sport
 verzinkbarepalen:
   data_endpoints: open_geodata/geojson.php?KAARTLAAG=VIS_BFA&THEMA=vis
 basiskaart:


### PR DESCRIPTION
The source endpoint has been changed for `openbareruimtes`. We received a new endpoint.