### PR TITLE
Oracle DB connection - require service name

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /tmp
 RUN wget -nv https://download.oracle.com/otn_software/linux/instantclient/19600/instantclient-basiclite-linux.x64-19.6.0.0.0dbru.zip
 RUN unzip instantclient-basiclite-linux.x64-19.6.0.0.0dbru.zip
 RUN cp -r  instantclient_19_6/* /usr/local/lib
+# Oracle DB connections to use encrypted connection
+RUN cd /usr/local/lib && echo SQLNET.ENCRYPTION_CLIENT=REQUIRED > ./network/admin/sqlnet.ora
 
 # Install sqlite3 from source, the default version for this Ubuntu-based image is too old
 RUN wget -c https://www.sqlite.org/2021/sqlite-autoconf-3360000.tar.gz

--- a/src/dags/common/db.py
+++ b/src/dags/common/db.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import cx_Oracle
 import dsnparse
 from airflow import AirflowException
 from airflow.providers.oracle.hooks.oracle import OracleHook
@@ -47,16 +48,35 @@ def get_engine(postgres_conn_id: str = "postgres_default") -> Engine:
 
 
 def get_ora_engine(oracle_conn_id: str = "oracle_default") -> Engine:
-    """Get the oracle connection parameters."""
+    """Get the oracle connection parameters.
+
+    Some KPN's Oracle databases are provided in a container that cannot
+        be accessed by a SID. A service_name parameter must be provided
+        in the connection string to make the connection to the source DB.
+    The Airflow OracleHook provides a method get_conn() that can be used to setup
+        the connection. However in contrast to a sqlalchemy connection it cannot
+        deal with processing Oracle's CLOB datatypes in combination with pandas.
+        Therefor the sqlalchemy create_engine is still used to build up
+        the connection.
+    """
     connection = OracleHook().get_connection(oracle_conn_id)
     user = connection.login
     password = connection.password
     host = connection.host
     port = connection.port
-    db = connection.schema
+    sid_ = (
+        connection.extra_dejson.get("sid")
+        if connection.extra_dejson.get("sid")
+        else connection.schema
+    )
+    service_name_ = connection.extra_dejson.get("service_name")
+    if service_name_:
+        dns = cx_Oracle.makedsn(host, port, service_name=service_name_)
+    else:
+        dns = cx_Oracle.makedsn(host, port, sid=sid_)
 
     try:
-        uri = f"oracle+cx_oracle://{user}:{password}@{host}:{port}/{db}?encoding=UTF-8&nencoding=UTF-8"  # noqa: E501
+        uri = f"oracle+cx_oracle://{user}:{password}@{dns}"
         return create_engine(uri, auto_convert_lobs=True)
     except SQLAlchemyError as e:
         raise AirflowException(str(e)) from e


### PR DESCRIPTION
Some of the resources use a Oracle DB that is hosted by KPN.
Currently these database require a specification of a SID of SERVICE NAME to connect. Containerized DB servers require SERVICE NAME.
The latter was not yet processable in current logic. To make sure that we can continue the processing of data in an Oracle database (that require now a service name), adjustments where made.