### PR TITLE
Oralce source DAGS that forgot to use new way of connecting

### DIFF
--- a/src/dags/importscripts/import_referentiekalender.py
+++ b/src/dags/importscripts/import_referentiekalender.py
@@ -1,10 +1,13 @@
+from contextlib import closing
+
 import pandas as pd
-from common.db import get_engine, get_ora_engine
+from common.db import get_engine, get_ora_engine, get_postgreshook_instance
+from psycopg2 import sql
 from sqlalchemy.types import Date, Integer, Text
 
 
 def load_from_dwh(table_name: str) -> None:
-    """Loads data from an Oracle database source into a Postgres database
+    """Loads data from an Oracle database source into a Postgres database.
 
     Args:
         table_name: The target table where the source data will be stored
@@ -15,9 +18,10 @@ def load_from_dwh(table_name: str) -> None:
         Note: The SQL processing is done with SQLAlchemy
 
     """
+    postgreshook_instance = get_postgreshook_instance()
     db_engine = get_engine()
     dwh_ora_engine = get_ora_engine("oracle_dwh_stadsdelen")
-    with dwh_ora_engine.connect() as connection:
+    with dwh_ora_engine.get_conn() as connection:
         df = pd.read_sql(
             """
             select "ID"
@@ -117,14 +121,14 @@ def load_from_dwh(table_name: str) -> None:
             "WEEK_IN_MAAND_EINDE_DATUM": Date(),
             "WEEK_IN_JAAR_NUMMER": Integer(),
             "ISO_WEEK_NUMMER": Integer(),
-            "JAAR_ISO_WEEKNR": Integer(),
+            "JAAR_ISO_WEEKNR": Text(),
             "ISO_WEEK_START_DATUM": Date(),
             "ISO_WEEK_EINDE_DATUM": Date(),
             "DAG_VAN_MAAND_NUMMER": Integer(),
             "MAAND_WAARDE": Integer(),
             "MAAND_NAAM": Text(),
             "MAAND_KNAAM": Text(),
-            "JAARMAAND": Integer(),
+            "JAARMAAND": Text(),
             "MAAND_START_DATUM": Text(),
             "MAAND_EINDE_DATUM": Text(),
             "DAGEN_IN_MAAND": Integer(),
@@ -132,7 +136,7 @@ def load_from_dwh(table_name: str) -> None:
             "DAG_VAN_KWARTAAL_NUMMER": Integer(),
             "KWARTAAL_WAARDE": Integer(),
             "KWARTAAL_NAAM": Text(),
-            "JAARKWARTAAL": Integer(),
+            "JAARKWARTAAL": Text(),
             "KWARTAAL_START_DATUM": Date(),
             "KWARTAAL_EINDE_DATUM": Date(),
             "DAGEN_IN_KWARTAAL": Integer(),
@@ -157,6 +161,14 @@ def load_from_dwh(table_name: str) -> None:
             "SCHOOLVAKANTIE_NL_ZUID_IND": Integer(),
             "NIVEAUCODE": Text(),
         }
+        # it seems that get_conn() makes the columns case sensitive
+        # lowercase all columns so the database will handle them as case insensitive
+        df.columns = map(str.lower, df.columns)
         df.to_sql(table_name, db_engine, if_exists="replace", dtype=dtype, index=False)
-        with db_engine.connect() as connection:
-            connection.execute(f"ALTER TABLE {table_name} ADD PRIMARY KEY (ID)")
+
+        with closing(postgreshook_instance.get_conn().cursor()) as cur:
+            cur.execute(
+                sql.SQL("ALTER TABLE {table_name} ADD PRIMARY KEY (ID)").format(
+                    table_name=sql.Identifier(table_name)
+                )
+            )


### PR DESCRIPTION
Due to a change how Oralce database are connected, by using the default OralceHook instance of Airflow, setting up the connection needed to be modified for Afval en Referentiekalender as well.

Beside the way of invoking the connection (a different method to apply), also some adjustements where made for:

- Preventing SQL injections
- Datatype changes for attributes
- Coping with case insensitive column names in the database