### PR TITLE
resource endpoint changes

### DIFF
--- a/src/dags/cmsa.py
+++ b/src/dags/cmsa.py
@@ -54,7 +54,7 @@ with DAG(
 
     download_geojson = HttpFetchOperator(
         task_id="download_geojson",
-        endpoint="open_geodata/geojson.php?KAARTLAAG=CROWDSENSOREN&THEMA=cmsa",
+        endpoint="open_geodata/geojson_lnglat.php?KAARTLAAG=CROWDSENSOREN&THEMA=cmsa",
         http_conn_id="ams_maps_conn_id",
         tmp_file=TMP_DIR / "sensors.geojson",
     )

--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -170,7 +170,7 @@ sport:
     geojson:
       openbaresportplek: open_geodata/geojson_latlng.php?KAARTLAAG=SPORT_OPENBAAR&THEMA=sport
 verzinkbarepalen:
-  data_endpoints: open_geodata/geojson.php?KAARTLAAG=VIS_BFA&THEMA=vis
+  data_endpoints: open_geodata/geojson_lnglat.php?KAARTLAAG=VIS_BFA&THEMA=vis
 basiskaart:
   # TODO: Amsterdam schema as source for object creation.
   tables_to_create:


### PR DESCRIPTION
The endpoints of the maps.amsterdam.nl resource are changed recently and therefore needed to be update in the DAG's that use them: CROWMONITOR and VERZINKBAREPALEN