### PR TITLE
BBGA: Fix: set PK to `variabele` instead of `sort`.

### DIFF
--- a/src/dags/sql/bbga_sqlite_transform.py
+++ b/src/dags/sql/bbga_sqlite_transform.py
@@ -10,10 +10,10 @@ DROP TABLE IF EXISTS bbga_indicatoren_definities;
  */
 CREATE TABLE IF NOT EXISTS bbga_indicatoren_definities
 (
-    sort                        BIGINT PRIMARY KEY,
+    sort                        BIGINT,
     begrotings_programma        VARCHAR,
     thema                       VARCHAR,
-    variabele                   VARCHAR NOT NULL,
+    variabele                   VARCHAR PRIMARY KEY,
     label                       VARCHAR,
     label_kort                  VARCHAR,
     definitie                   VARCHAR,


### PR DESCRIPTION
`Variabele` is the correct primary key. That is also how it is defined
in the Amsterdam Schema. Not sure why I originally set it to `sort` for
the duration of the import of the CSV.