### PR TITLE
fix for covid_19 => covid19

### DIFF
--- a/src/dags/covid19.py
+++ b/src/dags/covid19.py
@@ -22,15 +22,12 @@ from postgres_rename_operator import PostgresTableRenameOperator
 from provenance_rename_operator import ProvenanceRenameOperator
 from swift_operator import SwiftOperator
 
-# Note: to snake case is needed in target table because of the provenance check, because
-# number are seen as a start for underscore seperator. Covid19 is therefore translated as covid_19
-# TODO: change logic for snake_case when dealing with numbers
-dag_id = "covid_19"
+dag_id = "covid19"
 variables_covid19 = Variable.get("covid19", deserialize_json=True)
 files_to_download = variables_covid19["files_to_download"]
 
 # Note: Gebiedsverbod is absolete since "nieuwe tijdelijke wetgeving Corona maatregelen 01-12-2020"
-# TODO: remove Gebiedsverbod and Straatartiestverbod from var.yml, if DSO-API endpoint and 
+# TODO: remove Gebiedsverbod and Straatartiestverbod from var.yml, if DSO-API endpoint and
 # Amsterdam Schema definition can be removed.
 tables_to_create = variables_covid19["tables_to_create"]
 tables_to_check = {k: v for k, v in tables_to_create.items() if k not in ("gebiedsverbod", "straatartiestverbod")}


### PR DESCRIPTION
Since the removal of the underscore in the covid_19 dataset to covid19, the DAG was crashing. In the logic, especially on the rename of columns based on the Amsterdam schema it was expecting a table with underscore. Now the logic will look at covid19 (no underscore)