### PR TITLE
correction of drop temp tables, wrong names

### DIFF
--- a/src/dags/sql/rdw.py
+++ b/src/dags/sql/rdw.py
@@ -67,14 +67,16 @@ DROP TABLE IF EXISTS rdw_voertuig;
 DROP TABLE IF EXISTS rdw_voertuig_brandstof;
 DROP TABLE IF EXISTS rdw_voertuig_assen;
 DROP TABLE IF EXISTS rdw_voertuig_carrosserie;
+
 ALTER TABLE
 IF EXISTS rdw_voertuig_new RENAME TO rdw_voertuig;
 ALTER TABLE
 IF EXISTS rdw_voertuig_brandstof_new RENAME TO rdw_voertuig_brandstof;
 ALTER TABLE
 IF EXISTS rdw_voertuig_assen_new RENAME TO rdw_voertuig_assen;
-ALTER INDEX
+ALTER TABLE
 IF EXISTS rdw_voertuig_carrosserie_new RENAME TO rdw_voertuig_carrosserie;
+
 ALTER INDEX
 IF EXISTS rdw_voertuig_new_idx RENAME TO rdw_voertuig_idx;
 ALTER INDEX
@@ -83,6 +85,7 @@ ALTER INDEX
 IF EXISTS rdw_voertuig_brandstof_new_fk_idx RENAME TO rdw_voertuig_brandstof_fk_idx;
 ALTER INDEX
 IF EXISTS rdw_voertuig_carrosserie_new_fk_idx RENAME TO rdw_voertuig_carrosserie_fk_idx;
+
 ALTER TABLE
 IF EXISTS rdw_voertuig RENAME CONSTRAINT rdw_voertuig_new_pk
     TO rdw_voertuig_pk;

--- a/src/dags/sql/rdw.py
+++ b/src/dags/sql/rdw.py
@@ -7,8 +7,9 @@ from typing import Final
 # an object (array) within the schema definition.
 SQL_CREATE_TMP_TABLE: Final = """
 DROP TABLE IF EXISTS rdw_voertuig_new CASCADE;
-DROP TABLE IF EXISTS rdw_assen_new CASCADE;
-DROP TABLE IF EXISTS rdw_brandstof_new CASCADE;
+DROP TABLE IF EXISTS rdw_voertuig_assen_new CASCADE;
+DROP TABLE IF EXISTS rdw_voertuig_brandstof_new CASCADE;
+DROP TABLE IF EXISTS rdw_voertuig_carrosserie_new CASCADE;
 CREATE TABLE IF NOT EXISTS rdw_voertuig_new AS (
     SELECT b.id,
         b.kenteken,


### PR DESCRIPTION
Before creating temporary tables, they are dropped. However the wrong table names are used so when the process stops before the end, the temporary tables still remain. By a second run there temporary tables are not dropped. Leading to a duplicate error when creating indexes on for example these temporary tables. Hence, they already exists. By dropping the correct temporary tables the data can be correctly processed even when the ETL runs a second time after an uncompleted run.