### PR TITLE
due to source change, datatype had to changed from integer to numeric

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
   # Database for actual datasets, shared with DSO-API.
   dso_database:
     image: amsterdam/postgres11
+    shm_size: 1g
     ports:
       - "5416:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
   # Database for actual datasets, shared with DSO-API.
   dso_database:
     image: amsterdam/postgres11
-    shm_size: 1g
     ports:
       - "5416:5432"
     environment:

--- a/src/dags/horeca_exploitatievergunning.py
+++ b/src/dags/horeca_exploitatievergunning.py
@@ -13,7 +13,7 @@ from geoalchemy2 import Geometry
 from postgres_check_operator import PostgresCheckOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 from psycopg2 import sql
-from sqlalchemy.types import Date, Numeric, Text
+from sqlalchemy.types import Date, BigInteger, Text
 
 dag_id = "horeca_exploitatievergunning"
 
@@ -87,7 +87,7 @@ def load_from_dwh(table_name: str, source_srid: int) -> None:
             func=wkt_loads_wrapped, source_srid=source_srid
         )
         dtype = {
-            "zaaknummer": Numeric(),
+            "zaaknummer": BigInteger(),
             "zaaknaam": Text(),
             "zaakcategorie": Text(),
             "zaakspecificatie": Text(),

--- a/src/dags/horeca_exploitatievergunning.py
+++ b/src/dags/horeca_exploitatievergunning.py
@@ -13,7 +13,7 @@ from geoalchemy2 import Geometry
 from postgres_check_operator import PostgresCheckOperator
 from postgres_permissions_operator import PostgresPermissionsOperator
 from psycopg2 import sql
-from sqlalchemy.types import Date, Integer, Text
+from sqlalchemy.types import Date, Numeric, Text
 
 dag_id = "horeca_exploitatievergunning"
 
@@ -87,7 +87,7 @@ def load_from_dwh(table_name: str, source_srid: int) -> None:
             func=wkt_loads_wrapped, source_srid=source_srid
         )
         dtype = {
-            "zaaknummer": Integer(),
+            "zaaknummer": Numeric(),
             "zaaknaam": Text(),
             "zaakcategorie": Text(),
             "zaakspecificatie": Text(),


### PR DESCRIPTION
The range of the attribute zaaknummer has changed so it out ranges an integer datatype. It was therefore modified to bigint. 