### PR TITLE
fix wrong tables to drop

### DIFF
--- a/src/dags/rdw.py
+++ b/src/dags/rdw.py
@@ -103,10 +103,19 @@ with DAG(
         for resource in endpoints
     ]
 
+    keepalive_kwargs = {
+    "keepalives": 1,
+    "keepalives_idle": 60,
+    "keepalives_interval": 10,
+    "keepalives_count": 5
+    }
+
     # 5. SETUP tmp TABLE
     create_tmp_table = PostgresOperator(
         task_id="create_tmp_table",
         sql=SQL_CREATE_TMP_TABLE,
+        autocommit=True,
+        parameters={**keepalive_kwargs}
     )
 
     # 6. Rename COLUMNS based on provenance (if specified)

--- a/src/dags/sql/rdw.py
+++ b/src/dags/sql/rdw.py
@@ -7,8 +7,9 @@ from typing import Final
 # an object (array) within the schema definition.
 SQL_CREATE_TMP_TABLE: Final = """
 DROP TABLE IF EXISTS rdw_voertuig_new CASCADE;
-DROP TABLE IF EXISTS rdw_assen_new CASCADE;
-DROP TABLE IF EXISTS rdw_brandstof_new CASCADE;
+DROP TABLE IF EXISTS rdw_voertuig_assen_new CASCADE;
+DROP TABLE IF EXISTS rdw_voertuig_brandstof_new CASCADE;
+DROP TABLE IF EXISTS rdw_voertuig_brandstof_new CASCADE;
 CREATE TABLE IF NOT EXISTS rdw_voertuig_new AS (
     SELECT b.id,
         b.kenteken,
@@ -72,7 +73,7 @@ ALTER TABLE
 IF EXISTS rdw_voertuig_brandstof_new RENAME TO rdw_voertuig_brandstof;
 ALTER TABLE
 IF EXISTS rdw_voertuig_assen_new RENAME TO rdw_voertuig_assen;
-ALTER INDEX
+ALTER TABLE
 IF EXISTS rdw_voertuig_carrosserie_new RENAME TO rdw_voertuig_carrosserie;
 ALTER INDEX
 IF EXISTS rdw_voertuig_new_idx RENAME TO rdw_voertuig_idx;


### PR DESCRIPTION
Before creating temporary tables, they are dropped. However the wrong table names are used so when the process stops before the end, the temporary tables still remain. By a second run there temporary tables are not dropped. Leading to a duplicate error when creating indexes on for example these temporary tables. Hence, they already exists. By dropping the correct temporary tables the data can be correctly processed even when the ETL runs a second time after an uncompleted run.