### PR TITLE
beheerkaart not using correct database objects names

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-amsterdam-schema-tools == 2.2.1
+amsterdam-schema-tools == 3.0.1
 cattrs == 1.1.2
 apache-airflow[crypto,postgres,sentry,sendgrid] == 2.1.0
 apache-airflow-providers-microsoft-azure==3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,7 +11,7 @@ adal==1.2.7
     #   msrestazure
 alembic==1.5.5
     # via apache-airflow
-amsterdam-schema-tools==2.2.1
+amsterdam-schema-tools==3.0.1
     # via -r requirements.in
 anyio==3.3.3
     # via httpcore


### PR DESCRIPTION
Since the change in Amsterdam schema definition of beheerkaart, the dataset uses a camelCase as in `beheerkaartBasis`. The DAG that utilizes operators that for instance create a database object needs a snake cased equivalent. Also due to creating of objects in a database schema other then `public` as in `pte` the creating of tables in the explicit correct database schema was not in place leading to errors.