### PR TITLE
AB#24607 Add queries for gg[wp]gebieden

### DIFF
--- a/src/dags/graphql/gebieden-buurten-ligt_in_ggpgebied/args.json
+++ b/src/dags/graphql/gebieden-buurten-ligt_in_ggpgebied/args.json
@@ -1,0 +1,3 @@
+{
+  "extra_kwargs": {"is_through_table": true}
+}

--- a/src/dags/graphql/gebieden-buurten-ligt_in_ggpgebied/query.graphql
+++ b/src/dags/graphql/gebieden-buurten-ligt_in_ggpgebied/query.graphql
@@ -1,0 +1,16 @@
+
+    {
+      relGbdBrtGbdGgpLigtInGgpgebied(active: false) {
+        edges {
+          cursor
+          node {
+            srcId
+            srcVolgnummer
+            dstId
+            dstVolgnummer
+            beginGeldigheid
+            eindGeldigheid
+          }
+        }
+      }
+    }

--- a/src/dags/graphql/gebieden-buurten-ligt_in_ggwgebied/args.json
+++ b/src/dags/graphql/gebieden-buurten-ligt_in_ggwgebied/args.json
@@ -1,0 +1,3 @@
+{
+  "extra_kwargs": {"is_through_table": true}
+}

--- a/src/dags/graphql/gebieden-buurten-ligt_in_ggwgebied/query.graphql
+++ b/src/dags/graphql/gebieden-buurten-ligt_in_ggwgebied/query.graphql
@@ -1,0 +1,16 @@
+
+    {
+      relGbdBrtGbdGgwLigtInGgwgebied(active: false) {
+        edges {
+          cursor
+          node {
+            srcId
+            srcVolgnummer
+            dstId
+            dstVolgnummer
+            beginGeldigheid
+            eindGeldigheid
+          }
+        }
+      }
+    }

--- a/src/dags/graphql/gebieden-buurten/query.graphql
+++ b/src/dags/graphql/gebieden-buurten/query.graphql
@@ -21,6 +21,22 @@
             }
           }
         }
+        ligtInGgpgebied {
+          edges {
+            node {
+              identificatie
+              volgnummer
+            }
+          }
+        }
+        ligtInGgwgebied {
+          edges {
+            node {
+              identificatie
+              volgnummer
+            }
+          }
+        }
         geometrie
       }
     }

--- a/src/dags/graphql/gebieden-wijken-ligt_in_ggwgebied/args.json
+++ b/src/dags/graphql/gebieden-wijken-ligt_in_ggwgebied/args.json
@@ -1,0 +1,3 @@
+{
+  "extra_kwargs": {"is_through_table": true}
+}

--- a/src/dags/graphql/gebieden-wijken-ligt_in_ggwgebied/query.graphql
+++ b/src/dags/graphql/gebieden-wijken-ligt_in_ggwgebied/query.graphql
@@ -1,0 +1,16 @@
+
+    {
+      relGbdWijkGbdGgwLigtInGgwgebied(active: false) {
+        edges {
+          cursor
+          node {
+            srcId
+            srcVolgnummer
+            dstId
+            dstVolgnummer
+            beginGeldigheid
+            eindGeldigheid
+          }
+        }
+      }
+    }

--- a/src/dags/graphql/gebieden-wijken/query.graphql
+++ b/src/dags/graphql/gebieden-wijken/query.graphql
@@ -21,6 +21,14 @@
             }
           }
         }
+        ligtInGgwgebied {
+          edges {
+            node {
+              identificatie
+              volgnummer
+            }
+          }
+        }
         geometrie
       }
     }


### PR DESCRIPTION
For `gebieden.wijken` and `gebieden.buurten` extra relation fields
are exposed to `gebieden.ggwgebieden` and `gebieden.ggpgebieden`.

The grapql queries are updated to import these extra relations
into the ref. database.