### PR TITLE
bugfix in check on geometry

### DIFF
--- a/src/dags/sport.py
+++ b/src/dags/sport.py
@@ -280,7 +280,7 @@ with DAG(
             )
 
             total_checks = count_checks + geo_checks
-            check_name[resource] = total_checks
+            check_name[resource] = [*total_checks]
 
     # 15. Execute bundled checks on database
     multi_checks = [


### PR DESCRIPTION
Classic bug that prevents a check on geometry data. The code was reusing a list that holds the checks for each dataset, in stead of creating a list per dataset. Consequence was that the last check of a particular dataset was executed for all datasets. Masking issues on other datasets.