### PR TITLE
Modified Asbestdaken to new name

### DIFF
--- a/src/dags/asbestdaken.py
+++ b/src/dags/asbestdaken.py
@@ -20,10 +20,10 @@ from postgres_permissions_operator import PostgresPermissionsOperator
 from swift_operator import SwiftOperator
 
 SQL_RENAME_COL: Final = """
-ALTER TABLE asbest_daken_new RENAME COLUMN identifica TO pandidentificatie
+ALTER TABLE asbestdaken_daken_new RENAME COLUMN identifica TO pandidentificatie
 """
 
-dag_id = "asbest"
+dag_id = "asbestdaken"
 dag_config = Variable.get(dag_id, deserialize_json=True)
 
 with DAG(
@@ -52,7 +52,7 @@ with DAG(
     fetch_zip = SwiftOperator(
         task_id="fetch_zip",
         swift_conn_id="SWIFT_DEFAULT",
-        container=dag_id,
+        container="asbest",
         object_id=zip_file,
         output_path=f"{tmp_dir}/{zip_file}",
     )
@@ -91,7 +91,7 @@ with DAG(
     rename_tables = PostgresOperator(
         task_id="rename_tables",
         sql=SQL_TABLE_RENAMES,
-        params=dict(tablenames=rename_tablenames),
+        params={"tablenames": rename_tablenames},
     )
 
     rename_col = PostgresOperator(task_id="rename_col", sql=SQL_RENAME_COL)

--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -30,17 +30,17 @@ bekendmakingen:
       </Filter>
     outputFormat: application/json
   geotype: ST_Point
-asbest:
+asbestdaken:
   zip_file: Amsterdam_Asbestverdachte_daken_Shape.zip
   shp_files:
     - Asbestverdachte_daken_gegevens.shp
     - Asbestverdachte_Percelen.shp
   tables:
-    - asbest_daken_new
-    - asbest_percelen_new
+    - asbestdaken_daken_new
+    - asbestdaken_percelen_new
   rename_tablenames:
-    - asbest_daken
-    - asbest_percelen
+    - asbestdaken_daken
+    - asbestdaken_percelen
 vergunningen:
   files_to_download: [bb_quotum.sql, omzettingen_quotum.sql]
   table_source_names:


### PR DESCRIPTION
The DAG asbest was refering to asbestdaken. The latter being a recent change on the Amsterdam schema definition. Because the dataset was renamed from `asbest` to `asbestdaken` the permissions operator failed because it uses the DAG name for looking up the dataset name. So the DAG name must match the dataset name. If not we can specify a rename in the permissions operator. But that would be a last resort.