### PR TITLE
Non mount volume for generation the geopackage

### DIFF
--- a/src/dags/beheerkaart.py
+++ b/src/dags/beheerkaart.py
@@ -6,6 +6,7 @@ from bash_env_operator import BashEnvOperator
 from common import (
     DATAPUNT_ENVIRONMENT,
     DATASTORE_TYPE,
+    EPHEMERAL_DIR,
     MessageOperator,
     default_args,
     slack_webhook_token,
@@ -24,7 +25,7 @@ from swap_schema_operator import SwapSchemaOperator
 from swift_load_sql_operator import SwiftLoadSqlOperator
 
 dag_id = "beheerkaart"
-export_dir = f"/scratch-volume/{dag_id}"
+export_dir = f"{EPHEMERAL_DIR}/{dag_id}"
 tables = {
     "beheerkaart_basis_bgt": "bkt_bgt",
     "beheerkaart_basis_eigendomsrecht": "bkt_eigendomsrecht",

--- a/src/dags/common/__init__.py
+++ b/src/dags/common/__init__.py
@@ -36,6 +36,9 @@ ELIGIBLE_EMAIL_ENVIRONMENTS: tuple[str, ...] = tuple(
 
 SHARED_DIR: str = env("SHARED_DIR", "/tmp")  # noqa: S108
 
+# defines the an ephermeral directory used on an AKS pod non-mounted as a share.
+EPHEMERAL_DIR: str = env("EPHEMERAL_DIR", "/scratch-volume")  # noqa: S108
+
 DATASTORE_TYPE: str = (
     "acceptance" if DATAPUNT_ENVIRONMENT == "development" else DATAPUNT_ENVIRONMENT
 )


### PR DESCRIPTION
On AKS the /tmp directory is a shared mount. The generation of the geopackage requires an non-mounted volume. Also we do not need to keep the geopackage as a persistant file. Therefore the location of the export is set to a different location then /tmp. Being ephemeral.