### PR TITLE
Add extra logging for DB errors on GOB imports

### DIFF
--- a/src/plugins/http_gob_operator.py
+++ b/src/plugins/http_gob_operator.py
@@ -250,6 +250,7 @@ class HttpGobOperator(BaseOperator):
                         f"{SHARED_DIR}/{dataset_table_id}-{datetime.now().isoformat()}.ndjson",
                     )
                     Variable.set(f"{dataset_table_id}.cursor_pos", cursor_pos)
+                    self.log.exception("Database error")
                     raise AirflowException("A database error has occurred.") from e
 
                 self.log.info(


### PR DESCRIPTION
Turned out that errors are swallowed by airflow,
when DAGs are tested locally with `airflow tasks test ...`.

An extra log entry solves this problem.