### PR TITLE
bumped to higher version schema-tools

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-amsterdam-schema-tools == 3.3.6
+amsterdam-schema-tools == 3.3.7
 cattrs == 1.1.2
 apache-airflow[crypto,postgres,sentry,sendgrid] == 2.1.4
 apache-airflow-providers-microsoft-azure==3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,7 +11,7 @@ adal==1.2.7
     #   msrestazure
 alembic==1.7.1
     # via apache-airflow
-amsterdam-schema-tools==3.3.6
+amsterdam-schema-tools==3.3.7
     # via -r requirements.in
 anyio==3.3.3
     # via httpcore


### PR DESCRIPTION
On request of Datadiensten, to make sure this new version does not break any DAG's.