### PR TITLE
[FIX] lat and long twisted openbaresportplek data

### DIFF
--- a/src/dags/sport.py
+++ b/src/dags/sport.py
@@ -189,8 +189,10 @@ with DAG(
             target_table_name=f"{dag_id}_{resource}_new",
             input_file=f"{tmp_dir}/{resource}.{resource_format}",
             # the lat long in source openbaresportplek are twisted.
-            # So we need to correct it by switching it in reverse.
-            s_srs="+proj=latlong +datum=WGS84 +axis=neu +wktext" if resource == "openbaresportplek" else "EPSG:4326",
+            # So we need to correct it by switching it in reverse
+            s_srs="+proj=latlong +datum=WGS84 +axis=neu +wktext"
+            if resource == "openbaresportplek"
+            else "EPSG:4326",
             t_srs="EPSG:28992",
             input_file_sep="SEMICOLON",
             auto_detect_type="YES",

--- a/src/dags/sport.py
+++ b/src/dags/sport.py
@@ -188,7 +188,9 @@ with DAG(
             task_id=f"import_{resource}",
             target_table_name=f"{dag_id}_{resource}_new",
             input_file=f"{tmp_dir}/{resource}.{resource_format}",
-            s_srs="EPSG:4326",
+            # the lat long in source openbaresportplek are twisted.
+            # So we need to correct it by switching it in reverse.
+            s_srs="+proj=latlong +datum=WGS84 +axis=neu +wktext" if resource == "openbaresportplek" else "EPSG:4326",
             t_srs="EPSG:28992",
             input_file_sep="SEMICOLON",
             auto_detect_type="YES",


### PR DESCRIPTION
The lat and long of datasource openbaresportplekken was in reverse order. The lead to wrong conversion of WGS84 to 28992 geometry where the locations where not in the Amsterdam area any more (but in an other part of the world). To correct this we had to correct the order.