### PR TITLE
[NEW] wegenbestand dataset

### DIFF
--- a/src/dags/wegenbestand.py
+++ b/src/dags/wegenbestand.py
@@ -31,9 +31,9 @@ logger = logging.getLogger(__name__)
 db_conn = DatabaseEngine()
 
 DAG_ID: Final = "wegenbestand"
-# Wegenbestand holds a sub categorie ZZV `zone zwaarverkeer` for
+# Wegenbestand holds a sub categorie ZZV `zone zwaar verkeer` for
 # some tables to be listed under.
-DATASET_ID_ZZV: Final = "wegenbestandZoneZwaarverkeer"
+DATASET_ID_ZZV: Final = "wegenbestandZoneZwaarVerkeer"
 DATASET_ID_ZZV_DATABASE: Final = to_snake_case(DATASET_ID_ZZV)
 TMP_DIR: Final = Path(SHARED_DIR) / DAG_ID
 variables: dict[str, dict[str, str]] = Variable.get(DAG_ID, deserialize_json=True)
@@ -95,7 +95,7 @@ with DAG(
             db_conn=db_conn,
         )
         for values in data_values.values()
-        if values["source"] == "zone_zwaarverkeer"
+        if values["source"] == "zone_zwaar_verkeer"
         for resource_name, extention in files_to_download.items()
         if resource_name == values["source"]
     ]
@@ -125,9 +125,9 @@ with DAG(
     provenance_trans = [
         ProvenanceRenameOperator(
             task_id=f"provenance_rename_{values['table']}",
-            dataset_name=DATASET_ID_ZZV if values["source"] == "zone_zwaarverkeer" else DAG_ID,
+            dataset_name=DATASET_ID_ZZV if values["source"] == "zone_zwaar_verkeer" else DAG_ID,
             prefix_table_name=f"{DATASET_ID_ZZV_DATABASE}_"
-            if values["source"] == "zone_zwaarverkeer"
+            if values["source"] == "zone_zwaar_verkeer"
             else f"{DAG_ID}_",
             postfix_table_name="_new",
             rename_indexes=False,
@@ -143,7 +143,7 @@ with DAG(
             sql=SQL_GEOMETRY_VALID,
             params={
                 "tablename": f"{DATASET_ID_ZZV_DATABASE}_{values['table']}_new"
-                if values["source"] == "zone_zwaarverkeer"
+                if values["source"] == "zone_zwaar_verkeer"
                 else f"{DAG_ID}_{values['table']}_new",
                 "geo_column": "geometry",
                 "geom_type_number": 2,
@@ -165,7 +165,7 @@ with DAG(
                 pass_value=2,
                 params={
                     "table_name": f"{DATASET_ID_ZZV_DATABASE}_{values['table']}_new"
-                    if values["source"] == "zone_zwaarverkeer"
+                    if values["source"] == "zone_zwaar_verkeer"
                     else f"{DAG_ID}_{values['table']}_new"
                 },
                 result_checker=operator.ge,
@@ -177,7 +177,7 @@ with DAG(
                 check_id=f"geo_check_{values['table']}",
                 params={
                     "table_name": f"{DATASET_ID_ZZV_DATABASE}_{values['table']}_new"
-                    if values["source"] == "zone_zwaarverkeer"
+                    if values["source"] == "zone_zwaar_verkeer"
                     else f"{DAG_ID}_{values['table']}_new",
                     "geotype": [
                         "POINT",
@@ -206,10 +206,10 @@ with DAG(
             task_id=f"change_data_capture_{values['table']}",
             dataset_name=DATASET_ID_ZZV,
             source_table_name=f"{DATASET_ID_ZZV_DATABASE}_{values['table']}_new"
-            if values["source"] == "zone_zwaarverkeer"
+            if values["source"] == "zone_zwaar_verkeer"
             else f"{DAG_ID}_{values['table']}_new",
             target_table_name=f"{DATASET_ID_ZZV_DATABASE}_{values['table']}"
-            if values["source"] == "zone_zwaarverkeer"
+            if values["source"] == "zone_zwaar_verkeer"
             else f"{DAG_ID}_{values['table']}",
             drop_target_if_unequal=True,
         )
@@ -223,7 +223,7 @@ with DAG(
             sql=SQL_DROP_TMP_TABLE,
             params={
                 "tablename": f"{DATASET_ID_ZZV_DATABASE}_{values['table']}_new"
-                if values["source"] == "zone_zwaarverkeer"
+                if values["source"] == "zone_zwaar_verkeer"
                 else f"{DAG_ID}_{values['table']}_new"
             },
         )
@@ -278,9 +278,9 @@ dag.doc_md = """
     https://api.data.amsterdam.nl/v1/docs/datasets/wegenbestand.html
     https://api.data.amsterdam.nl/v1/docs/wfs-datasets/wegenbestand.html
     Example geosearch:
-    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/binnen&x=120320&y=488448&radius=10
-    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/buiten&x=120320&y=488448&radius=10
-    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/breed_opgezette_wegen&x=120320&y=488448&radius=10
-    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/routes_gevaarlijke_stoffen&x=118601&y=490715&radius=1
-    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/tunnels_gevaarlijke_stoffen&x=124630&y=480803&radius=1
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaar_verkeer/binnen&x=120320&y=488448&radius=10
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaar_verkeer/buiten&x=120320&y=488448&radius=10
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaar_verkeer/breed_opgezette_wegen&x=120320&y=488448&radius=10
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaar_verkeer/routes_gevaarlijke_stoffen&x=118601&y=490715&radius=1
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaar_verkeer/tunnels_gevaarlijke_stoffen&x=124630&y=480803&radius=1
 """

--- a/src/dags/wegenbestand.py
+++ b/src/dags/wegenbestand.py
@@ -88,7 +88,7 @@ with DAG(
             sql_statement="SELECT *"  # noqa: S608
             f" FROM {quote_string(values['geopackage_layer'])}"
             f" WHERE zone_zzv = {quote_string(values['data_filter'])}",
-            input_file=f"{TMP_DIR}/{resource_name}.{extention['file_type']}",
+            input_file=f"{TMP_DIR}/{resource_name}.{extension['file_type']}",
             t_srs="EPSG:28992",
             mode="PostgreSQL",
             nln_options=[f"{DATASET_ID_ZZV_DATABASE}_{values['table']}_new"],
@@ -96,7 +96,7 @@ with DAG(
         )
         for values in data_values.values()
         if values["source"] == "zone_zwaar_verkeer"
-        for resource_name, extention in files_to_download.items()
+        for resource_name, extension in files_to_download.items()
         if resource_name == values["source"]
     ]
 
@@ -105,14 +105,14 @@ with DAG(
         Ogr2OgrOperator(
             task_id=f"import_geojson_{values['table']}",
             target_table_name=f"{DAG_ID}_{values['table']}_new",
-            input_file=f"{TMP_DIR}/{values['table']}.{extention['file_type']}",
+            input_file=f"{TMP_DIR}/{values['table']}.{extension['file_type']}",
             t_srs="EPSG:28992",
             mode="PostgreSQL",
             db_conn=db_conn,
         )
         for values in data_values.values()
         if values["source"] in ("routes_gevaarlijke_stoffen", "tunnels_gevaarlijke_stoffen")
-        for resource_name, extention in files_to_download.items()
+        for resource_name, extension in files_to_download.items()
         if resource_name == values["source"]
     ]
 
@@ -265,7 +265,7 @@ clean_ups >> grant_db_permissions
 
 dag.doc_md = """
     #### DAG summary
-    This DAG contains data about city accesibility routes/zones for heavy classified traffic.
+    This DAG contains data about city accessibility routes/zones for heavy classified traffic.
     #### Mission Critical
     Classified as 2 (beschikbaarheid [range: 1,2,3])
     #### On Failure Actions

--- a/src/dags/wegenbestand.py
+++ b/src/dags/wegenbestand.py
@@ -1,0 +1,258 @@
+import logging
+import operator
+from pathlib import Path
+from typing import Final
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.dummy import DummyOperator
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+from common import (
+    DATAPUNT_ENVIRONMENT,
+    SHARED_DIR,
+    MessageOperator,
+    default_args,
+    quote_string,
+    slack_webhook_token,
+)
+from common.db import DatabaseEngine
+from common.path import mk_dir
+from contact_point.callbacks import get_contact_point_on_failure_callback
+from http_fetch_operator import HttpFetchOperator
+from ogr2ogr_operator import Ogr2OgrOperator
+from postgres_check_operator import COUNT_CHECK, GEO_CHECK, PostgresMultiCheckOperator
+from postgres_permissions_operator import PostgresPermissionsOperator
+from postgres_table_copy_operator import PostgresTableCopyOperator
+from provenance_rename_operator import ProvenanceRenameOperator
+from schematools.utils import to_snake_case
+from sql.common_queries import SQL_DROP_TMP_TABLE, SQL_GEOMETRY_VALID
+
+logger = logging.getLogger(__name__)
+db_conn = DatabaseEngine()
+
+DAG_ID: Final = "wegenbestand"
+DATASET_ID: Final = "wegenbestandZoneZwaarverkeer"
+DATASET_ID_DATABASE: Final = to_snake_case(DATASET_ID)
+TMP_DIR: Final = Path(SHARED_DIR) / DAG_ID
+variables: dict[str, dict[str, str]] = Variable.get(DAG_ID, deserialize_json=True)
+files_to_download: dict[str, dict[str, str]] = variables["files_to_download"]  # type: ignore
+data_values: dict[str, dict[str, str]] = variables["data_values"]  # type: ignore
+total_checks: list = []
+count_checks: list = []
+geo_checks: list = []
+check_name: dict = {}
+
+
+with DAG(
+    DAG_ID,
+    description="""Wegenbestand Amsterdam bevat gegevens over stedelijke zones voor zwaarverkeer
+                en tunnels/routes voor vervoer gevaarlijkestoffen.""",
+    default_args=default_args,
+    user_defined_filters={"quote": quote_string},
+    on_failure_callback=get_contact_point_on_failure_callback(dataset_id=DAG_ID),
+) as dag:
+
+    # 1. Post info message on slack
+    slack_at_start = MessageOperator(
+        task_id="slack_at_start",
+        http_conn_id="slack",
+        webhook_token=slack_webhook_token,
+        message=f"Starting {DAG_ID} ({DATAPUNT_ENVIRONMENT})",
+        username="admin",
+    )
+
+    # 2. Create temp directory to store files
+    mkdir = mk_dir(Path(TMP_DIR))
+
+    # 3. download .geopackage data from data.amsterdam.nl
+    download_data = [
+        HttpFetchOperator(
+            task_id=f"download_{values['file_type']}_{resource_name}",
+            endpoint=values["url"],
+            http_conn_id="api_data_amsterdam_conn_id",
+            tmp_file=f"{TMP_DIR}/{resource_name}.{values['file_type']}",
+        )
+        for resource_name, values in files_to_download.items()
+    ]
+
+    # 4. Dummy operator acts as an interface between parallel tasks to another parallel
+    # tasks with different number of lanes (without this intermediar, Airflow will raise an error)
+    Interface = DummyOperator(task_id="interface")
+
+    # 5a. path 1: import geopackage to database
+    load_geopackage = [
+        Ogr2OgrOperator(
+            task_id=f"import_gpkg_layer_{values['table']}",
+            sql_statement="SELECT *"  # noqa: S608
+            f" FROM {quote_string(values['geopackage_layer'])}"
+            f" WHERE zone_zzv = {quote_string(values['data_filter'])}",
+            input_file=f"{TMP_DIR}/{resource_name}.{extention['file_type']}",
+            t_srs="EPSG:28992",
+            mode="PostgreSQL",
+            nln_options=[f"{DATASET_ID_DATABASE}_{values['table']}_new"],
+            db_conn=db_conn,
+        )
+        for values in data_values.values()
+        if values["source"] == "zone_zwaarverkeer"
+        for resource_name, extention in files_to_download.items()
+        if resource_name == values["source"]
+    ]
+
+    # 5b. path 2: import geojson to database
+    load_geojson = [
+        Ogr2OgrOperator(
+            task_id=f"import_geojson_{values['table']}",
+            target_table_name=f"{DATASET_ID_DATABASE}_{values['table']}_new",
+            input_file=f"{TMP_DIR}/{values['table']}.{extention['file_type']}",
+            t_srs="EPSG:28992",
+            mode="PostgreSQL",
+            db_conn=db_conn,
+        )
+        for values in data_values.values()
+        if values["source"] in ("routes_gevaarlijke_stoffen", "tunnels_gevaarlijke_stoffen")
+        for resource_name, extention in files_to_download.items()
+        if resource_name == values["source"]
+    ]
+
+    # 6. RENAME columns based on PROVENANCE
+    provenance_trans = ProvenanceRenameOperator(
+        task_id="provenance_rename",
+        dataset_name=DATASET_ID,
+        prefix_table_name=f"{DATASET_ID_DATABASE}_",
+        postfix_table_name="_new",
+        rename_indexes=False,
+        pg_schema="public",
+    )
+
+    # 7. Make geometry valid
+    make_geo_valid = [
+        PostgresOperator(
+            task_id=f"make_geo_valid_{values['table']}",
+            sql=SQL_GEOMETRY_VALID,
+            params={
+                "tablename": f"{DATASET_ID_DATABASE}_{values['table']}_new",
+                "geo_column": "geometry",
+                "geom_type_number": 2,
+            },
+        )
+        for values in data_values.values()
+    ]
+
+    # Prepare the checks and added them per source to a dictionary
+    for values in data_values.values():
+
+        total_checks.clear()
+        count_checks.clear()
+        geo_checks.clear()
+
+        count_checks.append(
+            COUNT_CHECK.make_check(
+                check_id=f"count_check_{values['table']}",
+                pass_value=2,
+                params={"table_name": f"{DATASET_ID_DATABASE}_{values['table']}_new"},
+                result_checker=operator.ge,
+            )
+        )
+
+        geo_checks.append(
+            GEO_CHECK.make_check(
+                check_id=f"geo_check_{values['table']}",
+                params={
+                    "table_name": f"{DATASET_ID_DATABASE}_{values['table']}_new",
+                    "geotype": [
+                        "POINT",
+                        "MULTILINESTRING",
+                    ],
+                },
+                pass_value=1,
+            )
+        )
+
+        total_checks = count_checks + geo_checks
+        check_name[values["table"]] = [*total_checks]
+
+    # 8. Execute bundled checks on database
+    multi_checks = [
+        PostgresMultiCheckOperator(
+            task_id=f"multi_check_{values['table']}",
+            checks=check_name[values["table"]],
+        )
+        for values in data_values.values()
+    ]
+
+    # 9. Check for changes to merge in target table
+    change_data_capture = [
+        PostgresTableCopyOperator(
+            task_id=f"change_data_capture_{values['table']}",
+            dataset_name=DATASET_ID,
+            source_table_name=f"{DATASET_ID_DATABASE}_{values['table']}_new",
+            target_table_name=f"{DATASET_ID_DATABASE}_{values['table']}",
+            drop_target_if_unequal=True,
+        )
+        for values in data_values.values()
+    ]
+
+    # 10. Clean up (remove temp table _new)
+    clean_ups = [
+        PostgresOperator(
+            task_id=f"clean_up_{values['table']}",
+            sql=SQL_DROP_TMP_TABLE,
+            params={"tablename": f"{DATASET_ID_DATABASE}_{values['table']}_new"},
+        )
+        for values in data_values.values()
+    ]
+
+    # 11. Grant database permissions
+    grant_db_permissions = PostgresPermissionsOperator(task_id="grants", dag_name=DAG_ID)
+
+
+# FLOW
+slack_at_start >> mkdir >> download_data
+
+for download in zip(download_data):
+    [download]
+
+# Path 1: geopackage import
+download_data >> Interface >> load_geopackage
+
+for import_geopackage in zip(load_geopackage):
+    [import_geopackage]
+
+# Path 2: geojson import
+Interface >> load_geojson
+
+for import_geojson in zip(load_geojson):
+    [import_geojson]
+
+# Merge path 1&2: and continue main path
+load_geopackage >> provenance_trans
+load_geojson >> provenance_trans >> make_geo_valid
+
+for (geo_valid, multi_check, capture_data, clean_up) in zip(
+    make_geo_valid, multi_checks, change_data_capture, clean_ups
+):
+    [geo_valid >> multi_check >> capture_data >> clean_up]
+
+clean_ups >> grant_db_permissions
+
+dag.doc_md = """
+    #### DAG summary
+    This DAG contains data about city accesibility routes/zones for heavy classified traffic.
+    #### Mission Critical
+    Classified as 2 (beschikbaarheid [range: 1,2,3])
+    #### On Failure Actions
+    Fix issues and rerun dag on working days
+    #### Point of Contact
+    Inform the businessowner (Bas Bussink) at bereikbaarheidsthermometer@amsterdam.nl
+    #### Business Use Case / process / origin
+    Na
+    #### Prerequisites/Dependencies/Resourcing
+    https://api.data.amsterdam.nl/v1/docs/datasets/wegenbestand.html
+    https://api.data.amsterdam.nl/v1/docs/wfs-datasets/wegenbestand.html
+    Example geosearch:
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/binnen&x=120320&y=488448&radius=10
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/buiten&x=120320&y=488448&radius=10
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/breed_opgezette_wegen&x=120320&y=488448&radius=10
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/routes_gevaarlijke_stoffen&x=118601&y=490715&radius=1
+    https://api.data.amsterdam.nl/geosearch?datasets=wegenbestand_zone_zwaarverkeer/tunnels_gevaarlijke_stoffen&x=124630&y=480803&radius=1
+"""

--- a/src/plugins/postgres_permissions_operator.py
+++ b/src/plugins/postgres_permissions_operator.py
@@ -145,21 +145,17 @@ class PostgresPermissionsOperator(BaseOperator):
             if executed_dags_after_delta:
 
                 for self.dataset_name in executed_dags_after_delta:
+                    dataset_name = []
 
                     # get real datasetname from DAG_DATASET constant, if dag_id != dataschema name
                     for key in DAG_DATASET.keys():
-                        if key in self.dataset_name:
-                            self.dataset_name = DAG_DATASET[key]
-                        # if dataset_name is just a string value, convert it into a list
-                        # so we can use it as an iterable in the grants
-                        # allocation in the next section.
-                        if not isinstance(self.dataset_name, list):
-                            self.dataset_name = [
-                                self.dataset_name,
-                            ]
+                        if self.dataset_name and key in self.dataset_name:
+                            dataset_name.append(DAG_DATASET[key])
+                        elif self.dataset_name:
+                            dataset_name.append(self.dataset_name)
                         break
 
-                    for dataset in self.dataset_name:
+                    for dataset in dataset_name:
 
                         logger.info("set grants for %s", dataset)
 
@@ -194,21 +190,17 @@ class PostgresPermissionsOperator(BaseOperator):
 
         # Option TWO: grant on single dataset (can be used as a final step within a single DAG run)
         elif self.dataset_name and not self.batch_ind:
+            dataset_name = []
 
             # get real datasetname from DAG_DATASET constant, if dag_id != dataschema name
             for key in DAG_DATASET.keys():
                 if key in self.dataset_name:
-                    self.dataset_name = DAG_DATASET[key]
-                # if dataset_name is just a string value, convert it into a list
-                # so we can use it as an iterable in the grants
-                # allocation in the next section.
-                if not isinstance(self.dataset_name, list):
-                    self.dataset_name = [
-                        self.dataset_name,
-                    ]
+                    dataset_name.append(DAG_DATASET[key])
+                else:
+                    dataset_name.append(self.dataset_name)
                 break
 
-            for dataset in self.dataset_name:
+            for dataset in dataset_name:
 
                 logger.info("set grants for %s", dataset)
 

--- a/src/plugins/postgres_permissions_operator.py
+++ b/src/plugins/postgres_permissions_operator.py
@@ -41,6 +41,7 @@ DAG_DATASET: Final = {
     "reclamebelasting": "belastingen",
     "processenverbaalverkiezingen": "verkiezingen",
     "financien_": "financien",
+    "wegenbestand": "wegenbestandZoneZwaarverkeer",
 }
 
 

--- a/src/plugins/postgres_permissions_operator.py
+++ b/src/plugins/postgres_permissions_operator.py
@@ -41,7 +41,7 @@ DAG_DATASET: Final = {
     "reclamebelasting": "belastingen",
     "processenverbaalverkiezingen": "verkiezingen",
     "financien_": "financien",
-    "wegenbestand": "wegenbestandZoneZwaarverkeer",
+    "wegenbestand": "wegenbestandZoneZwaarVerkeer",
 }
 
 

--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -363,10 +363,10 @@ wegenbestand:
   files_to_download:
     routes_gevaarlijke_stoffen: {"url": "dcatd/datasets/ZtMOaEZSOnXM9w/purls/1", "file_type": "geojson"}
     tunnels_gevaarlijke_stoffen: {"url": "dcatd/datasets/ZtMOaEZSOnXM9w/purls/2", "file_type": "geojson"}
-    zone_zwaarverkeer: {"url": "dcatd/datasets/YLTyzpWP6Vz2QQ/purls/1", "file_type": "gpkg"}
+    zone_zwaar_verkeer: {"url": "dcatd/datasets/YLTyzpWP6Vz2QQ/purls/1", "file_type": "gpkg"}
   data_values:
-    table_1: {"table":"binnen", "geopackage_layer": "vma400_20212201_undirected","data_filter": "binnen", "source": "zone_zwaarverkeer"}
-    table_2: {"table":"buiten", "geopackage_layer": "vma400_20212201_undirected","data_filter": "buiten", "source": "zone_zwaarverkeer"}
-    table_3: {"table":"breed_opgezette_wegen", "geopackage_layer": "vma400_20212201_undirected", "data_filter": "binnen - breed opgezette wegen", "source": "zone_zwaarverkeer"}
+    table_1: {"table":"binnen", "geopackage_layer": "vma400_20212201_undirected","data_filter": "binnen", "source": "zone_zwaar_verkeer"}
+    table_2: {"table":"buiten", "geopackage_layer": "vma400_20212201_undirected","data_filter": "buiten", "source": "zone_zwaar_verkeer"}
+    table_3: {"table":"breed_opgezette_wegen", "geopackage_layer": "vma400_20212201_undirected", "data_filter": "binnen - breed opgezette wegen", "source": "zone_zwaar_verkeer"}
     table_4: {"table":"routes_gevaarlijke_stoffen", "data_filter": None, "source": "routes_gevaarlijke_stoffen"}
     table_5: {"table":"tunnels_gevaarlijke_stoffen", "data_filter": None, "source": "tunnels_gevaarlijke_stoffen"}

--- a/src/vars/vars.yaml
+++ b/src/vars/vars.yaml
@@ -359,3 +359,14 @@ hoofdroutes:
   files_to_download:
     routes_gevaarlijke_stoffen: dcatd/datasets/ZtMOaEZSOnXM9w/purls/1
     tunnels_gevaarlijke_stoffen: dcatd/datasets/ZtMOaEZSOnXM9w/purls/2
+wegenbestand:
+  files_to_download:
+    routes_gevaarlijke_stoffen: {"url": "dcatd/datasets/ZtMOaEZSOnXM9w/purls/1", "file_type": "geojson"}
+    tunnels_gevaarlijke_stoffen: {"url": "dcatd/datasets/ZtMOaEZSOnXM9w/purls/2", "file_type": "geojson"}
+    zone_zwaarverkeer: {"url": "dcatd/datasets/YLTyzpWP6Vz2QQ/purls/1", "file_type": "gpkg"}
+  data_values:
+    table_1: {"table":"binnen", "geopackage_layer": "vma400_20212201_undirected","data_filter": "binnen", "source": "zone_zwaarverkeer"}
+    table_2: {"table":"buiten", "geopackage_layer": "vma400_20212201_undirected","data_filter": "buiten", "source": "zone_zwaarverkeer"}
+    table_3: {"table":"breed_opgezette_wegen", "geopackage_layer": "vma400_20212201_undirected", "data_filter": "binnen - breed opgezette wegen", "source": "zone_zwaarverkeer"}
+    table_4: {"table":"routes_gevaarlijke_stoffen", "data_filter": None, "source": "routes_gevaarlijke_stoffen"}
+    table_5: {"table":"tunnels_gevaarlijke_stoffen", "data_filter": None, "source": "tunnels_gevaarlijke_stoffen"}


### PR DESCRIPTION
The wegenbestand contains data about so called `zones zwaar verkeer` en consists of roads within that zone, outside that zone and roads that needs a special waiver to be used. These three tables all fall within the main category wegenbestand and subcategory zones zwaar verkeer.

The existing datasets hoofdroutes, like `routes and tunnels gevaarlijke stoffen` are also placed on the `wegenbestand` but not under `zones zwaar verkeer`. They reside on the main level in that perspective.

The DAG hoofdroutes will be for now still active. In a later stadium that DAG will be de-allocated.