### PR TITLE
Fix table-init and -copy operator to handle nested tables

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-amsterdam-schema-tools == 3.3.7
+amsterdam-schema-tools == 3.4.1
 cattrs == 1.1.2
 apache-airflow[crypto,postgres,sentry,sendgrid] == 2.1.4
 apache-airflow-providers-microsoft-azure==3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,7 +11,7 @@ adal==1.2.7
     #   msrestazure
 alembic==1.7.1
     # via apache-airflow
-amsterdam-schema-tools==3.3.7
+amsterdam-schema-tools==3.4.1
     # via -r requirements.in
 anyio==3.3.3
     # via httpcore


### PR DESCRIPTION
In the PostgresTableInitOperator and the PostgresTableCopyOperator
the related tables are found based on the name of the base table.

However, when the base tablename has as `_new` postfix, this
approach does not work for the nested tables.

This has now been solved by passing the names of these nested tables
explicitly to these two operators.