### PR TITLE
changed pythonpath for 2 legacy DAG's

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -79,6 +79,9 @@ COPY vsd ${AIRFLOW_USER_HOME}/vsd
 # for instance can be located and used as a reference.
 ENV PYTHONPATH=$PYTHONPATH:$AIRFLOW_USER_HOME
 
+# temporary path adjustment for vsd biz and meldingen specific (TODO: need to convert it to standard dags)
+ENV PYTHONPATH=$PYTHONPATH:$AIRFLOW_USER_HOME/dags:$AIRFLOW_USER_HOME/vsd
+
 WORKDIR ${AIRFLOW_USER_HOME}
 ENTRYPOINT ["/docker-entrypoint.sh"]
 # CMD ["sleep", "infinity"]


### PR DESCRIPTION
The legacy DAG's BIZ and Meldingen (both under the /vsd folder) crashed due to not be able to import some packages. These DAG's need to be converted to "regular" DAG. For now, we just adjust the Python path to make them work on the short run.