### PR TITLE
Airflow laten verbinden met referentiedatabase op basis van Managed Identity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       AZURE_CLIENT_ID: f24e8603-a66f-46a5-a18f-db0dcc6fa86e
       AZURE_TENANT_ID: 72fca1b1-2c2e-4376-a445-294d80196804
       AIRFLOW_CONN_POSTGRES_DEFAULT:
-        "postgresql://mid-airflow-generic1-ont-weu-01@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
+        "postgresql://EM4W-DATA-dataset-ot-covid_19-rw@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
         /mdbdataservices?cursor=dictcursor&iam=true"
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgresql://ds_airflow:insecure@database:5432/ds_airflow"
       AIRFLOW_CONN_ORACLE_DWH_STADSDELEN: "oracle://oracle_user:insecure@localhost:1521/SID001?encoding=UTF-8&nencoding=UTF-8"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,11 @@ services:
       - database
       - dso_database
     environment:
+      AZURE_CLIENT_ID: f24e8603-a66f-46a5-a18f-db0dcc6fa86e
+      AZURE_TENANT_ID: 72fca1b1-2c2e-4376-a445-294d80196804
+      AIRFLOW_CONN_AIRFLOW_DB:
+        "postgresql://mid-airflow-generic1-ont-weu-01@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
+        /mdbdataservices?cursor=dictcursor&iam=true"
       AIRFLOW_CONN_POSTGRES_DEFAULT:
         "postgresql://dataservices:insecure@dso_database:5432\
         /dataservices?cursor=dictcursor&"
@@ -127,6 +132,7 @@ services:
       - ./src/vars:/usr/local/airflow/vars
       - ./src/vsd:/usr/local/airflow/vsd
       - ./develop:/usr/local/airflow/develop
+      - ./.vscode:/usr/local/airflow/.vscode
       - /var/run/docker.sock:/var/run/docker.sock
     # extra_hosts:
     #- "dockerhost:$DOCKERHOST"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,12 +31,9 @@ services:
     environment:
       AZURE_CLIENT_ID: f24e8603-a66f-46a5-a18f-db0dcc6fa86e
       AZURE_TENANT_ID: 72fca1b1-2c2e-4376-a445-294d80196804
-      AIRFLOW_CONN_AIRFLOW_DB:
+      AIRFLOW_CONN_POSTGRES_DEFAULT:
         "postgresql://mid-airflow-generic1-ont-weu-01@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
         /mdbdataservices?cursor=dictcursor&iam=true"
-      AIRFLOW_CONN_POSTGRES_DEFAULT:
-        "postgresql://dataservices:insecure@dso_database:5432\
-        /dataservices?cursor=dictcursor&"
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgresql://ds_airflow:insecure@database:5432/ds_airflow"
       AIRFLOW_CONN_ORACLE_DWH_STADSDELEN: "oracle://oracle_user:insecure@localhost:1521/SID001?encoding=UTF-8&nencoding=UTF-8"
       AIRFLOW_CONN_ORACLE_DWH_AMI: "oracle://oracle_user:insecure@localhost:port/database?encoding=UTF-8&nencoding=UTF-8"

--- a/src/dags/testdag.py
+++ b/src/dags/testdag.py
@@ -82,10 +82,10 @@ with DAG(
         "SELECT * FROM public.covid_19_alcoholverkoopverbod;",
     ]
     pg_update_azure_token_test = PostgresUpdateAzureTokenOperator(
-        task_id="pg_update_azure_token_test", postgres_conn_id="airflow_db"
+        task_id="pg_update_azure_token_test", postgres_conn_id="postgres_default"
     )
     pgtest = PostgresOperator(
-        task_id="pgtest", postgres_conn_id="airflow_db", sql=sqls
+        task_id="pgtest", postgres_conn_id="postgres_default", sql=sqls
     )
     pg_update_azure_token_test >> pgtest
 

--- a/src/dags/testdag.py
+++ b/src/dags/testdag.py
@@ -82,10 +82,10 @@ with DAG(
         "SELECT * FROM public.covid_19_alcoholverkoopverbod;",
     ]
     pg_update_azure_token_test = PostgresUpdateAzureTokenOperator(
-        task_id="pg_update_azure_token_test", postgres_conn_id="postgres_default"
+        task_id="pg_update_azure_token_test", postgres_conn_id="postgres_default", generated_postgres_conn_id="postgres_azure"
     )
     pgtest = PostgresOperator(
-        task_id="pgtest", postgres_conn_id="postgres_default", sql=sqls
+        task_id="pgtest", postgres_conn_id="postgres_azure", sql=sqls
     )
     pg_update_azure_token_test >> pgtest
 

--- a/src/plugins/postgres_on_azure_hook.py
+++ b/src/plugins/postgres_on_azure_hook.py
@@ -1,4 +1,3 @@
-import os
 from typing import Tuple
 
 from airflow.models.connection import Connection
@@ -17,15 +16,15 @@ class PostgresOnAzureHook(PostgresHook):
         # This class uses DefaultAzureCredential which will pick up the managed identity
         # using the AZURE_TENANT_ID and AZURE_CLIENT_ID environment variables.
         # Then set the connection using an env var like this:
-        # AIRFLOW_CONN_POSTGRES_AZURE:
-        # "postgresql://mid-airflow-generic1-ont-weu-01@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
-        # /dataservices?cursor=dictcursor&iam=true"
+        # AIRFLOW_CONN_POSTGRES_DEFAULT:
+        # "postgresql://EM4W-DATA-dataset-ot-covid_19-rw@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
+        # /mdbdataservices?cursor=dictcursor&iam=true"
 
-        # host = conn.host        # <server_name>.postgres.database.azure.com'
-        # server_name = host.partition('.')[0]
+        # Note that for managed identities the group name needs to be used in the connection string.
 
-        # mid_db_username is something like: `mid_airflow_benkbbn1_ont_weu_01`.
-        # Beware! This DB user needs to be created in the referentie DB as an AAD related user.
+        # Beware! The group or user needs to be registered in the database as an AAD related user.
+        # See https://docs.microsoft.com/en-us/azure/postgresql/single-server/how-to-configure-sign-in-azure-ad-authentication#authenticate-with-azure-ad-as-a-group-member
+        # for reference
 
         login = conn.login  # <mid_db_username>@<server_name>
         password = self.get_token_with_msi()

--- a/src/plugins/postgres_on_azure_hook.py
+++ b/src/plugins/postgres_on_azure_hook.py
@@ -26,7 +26,7 @@ class PostgresOnAzureHook(PostgresHook):
         # See https://docs.microsoft.com/en-us/azure/postgresql/single-server/how-to-configure-sign-in-azure-ad-authentication#authenticate-with-azure-ad-as-a-group-member
         # for reference
 
-        login = conn.login  # <mid_db_username>@<server_name>
+        login = conn.login  # <group_name>@<server_name>
         password = self.get_token_with_msi()
 
         _LOGGER.info(conn.get_uri())

--- a/src/plugins/postgres_on_azure_hook.py
+++ b/src/plugins/postgres_on_azure_hook.py
@@ -35,12 +35,7 @@ class PostgresOnAzureHook(PostgresHook):
         return login, password, port
 
     def get_token_with_msi(self):
-        mid_client_id = os.getenv("USER_ASSIGNED_MANAGED_IDENTITY")
-
-        if not mid_client_id:
-            credential = DefaultAzureCredential(managed_identity_client_id=mid_client_id)
-            scope = "https://ossrdbms-aad.database.windows.net/.default"
-            token = credential.get_token(scope).token
-            return token
-        else:
-            raise UserWarning("USER_ASSIGNED_MANAGED_IDENTITY env var was not set")
+        credential = DefaultAzureCredential()
+        scope = "https://ossrdbms-aad.database.windows.net/.default"
+        token = credential.get_token(scope).token
+        return token

--- a/src/plugins/postgres_on_azure_hook.py
+++ b/src/plugins/postgres_on_azure_hook.py
@@ -29,7 +29,7 @@ class PostgresOnAzureHook(PostgresHook):
         login = conn.login  # <group_name>@<server_name>
         password = self.get_token_with_msi()
 
-        _LOGGER.info(conn.get_uri())
+        _LOGGER.info("uri: %s".format(conn.get_uri()))
         _LOGGER.info(f"username: {login} password: {password}")
 
         if conn.port is None:

--- a/src/plugins/postgres_on_azure_hook.py
+++ b/src/plugins/postgres_on_azure_hook.py
@@ -1,0 +1,46 @@
+import os
+from typing import Tuple
+
+from airflow.models.connection import Connection
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from azure.identity import DefaultAzureCredential
+
+
+class PostgresOnAzureHook(PostgresHook):
+    def get_iam_token(self, conn: Connection) -> Tuple[str, str, int]:
+        """
+        Override PostgresHook get_iam_token with Azure logic
+        """
+
+        # Make sure that USER_ASSIGNED_MANAGED_IDENTITY is set to the client id of
+        # the managed identity. Then set the connection using an env var like this:
+        # AIRFLOW_CONN_POSTGRES_AZURE:
+        # "postgresql://mid-airflow-generic1-ont-weu-01@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
+        # /dataservices?cursor=dictcursor&iam=true"
+
+        # host = conn.host        # <server_name>.postgres.database.azure.com'
+        # server_name = host.partition('.')[0]
+
+        # mid_db_username is something like: `mid_airflow_benkbbn1_ont_weu_01`.
+        # Beware! This DB user needs to be created in the referentie DB as an AAD related user.
+
+        login = conn.login  # <mid_db_username>@<server_name>
+        password = self.get_token_with_msi()
+
+        if conn.port is None:
+            port = 5432
+        else:
+            port = conn.port
+
+        return login, password, port
+
+    def get_token_with_msi(self):
+        mid_client_id = os.getenv("USER_ASSIGNED_MANAGED_IDENTITY")
+
+        if not mid_client_id:
+            credential = DefaultAzureCredential(managed_identity_client_id=mid_client_id)
+            scope = "https://ossrdbms-aad.database.windows.net/.default"
+            token = credential.get_token(scope).token
+            return token
+        else:
+            raise UserWarning("USER_ASSIGNED_MANAGED_IDENTITY env var was not set")

--- a/src/plugins/postgres_on_azure_hook.py
+++ b/src/plugins/postgres_on_azure_hook.py
@@ -3,9 +3,6 @@ from typing import Tuple
 from airflow.models.connection import Connection
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from azure.identity import DefaultAzureCredential
-import logging
-
-_LOGGER = logging.getLogger(__name__)
 
 class PostgresOnAzureHook(PostgresHook):
     def get_iam_token(self, conn: Connection) -> Tuple[str, str, int]:
@@ -28,9 +25,6 @@ class PostgresOnAzureHook(PostgresHook):
 
         login = conn.login  # <group_name>@<server_name>
         password = self.get_token_with_msi()
-
-        _LOGGER.info("uri: %s".format(conn.get_uri()))
-        _LOGGER.info(f"username: {login} password: {password}")
 
         if conn.port is None:
             port = 5432

--- a/src/plugins/postgres_on_azure_operator.py
+++ b/src/plugins/postgres_on_azure_operator.py
@@ -35,11 +35,15 @@ class PostgresOnAzureOperator(BaseOperator):
         Template references are recognized by str ending in '.sql'
     :param postgres_conn_id: The :ref:`postgres conn id <howto/connection:postgres>`
         reference to a specific postgres database.
-        Make sure that USER_ASSIGNED_MANAGED_IDENTITY is set to the client id of
-        the managed identity. Then set the connection using an env var like this:
-        AIRFLOW_CONN_POSTGRES_AZURE:
-        "postgresql://mid-airflow-generic1-ont-weu-01@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
-        /dataservices?cursor=dictcursor&iam=true"
+        DefaultAzureCredential is used which will pick up the managed identity
+        using the AZURE_TENANT_ID and AZURE_CLIENT_ID environment variables.
+        Then set the connection using an env var like this:
+        AIRFLOW_CONN_POSTGRES_DEFAULT:
+        postgresql://EM4W-DATA-dataset-ot-covid_19-rw@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432/mdbdataservices?cursor=dictcursor&iam=true
+        Note that for managed identities the group name needs to be used in the connection string.
+        Beware! The group or user needs to be registered in the database as an AAD related user.
+        See https://docs.microsoft.com/en-us/azure/postgresql/single-server/how-to-configure-sign-in-azure-ad-authentication#authenticate-with-azure-ad-as-a-group-member
+        for reference
     :param autocommit: if True, each command is automatically committed.
         (default value: False)
     :param parameters: (optional) the parameters to render the SQL query with.

--- a/src/plugins/postgres_on_azure_operator.py
+++ b/src/plugins/postgres_on_azure_operator.py
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, Union
+
+from psycopg2.sql import SQL, Identifier
+
+from airflow.models import BaseOperator
+from postgres_on_azure_hook import PostgresOnAzureHook
+from airflow.www import utils as wwwutils
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class PostgresOnAzureOperator(BaseOperator):
+    """
+    Executes sql code in a specific Postgres database
+    :param sql: the SQL code to be executed as a single string, or
+        a list of str (sql statements), or a reference to a template file.
+        Template references are recognized by str ending in '.sql'
+    :param postgres_conn_id: The :ref:`postgres conn id <howto/connection:postgres>`
+        reference to a specific postgres database.
+        Make sure that USER_ASSIGNED_MANAGED_IDENTITY is set to the client id of
+        the managed identity. Then set the connection using an env var like this:
+        AIRFLOW_CONN_POSTGRES_AZURE:
+        "postgresql://mid-airflow-generic1-ont-weu-01@dev-bbn1-00-dbhost:replacedbymidtoken@dev-bbn1-00-dbhost.postgres.database.azure.com:5432\
+        /dataservices?cursor=dictcursor&iam=true"
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :param database: name of database which overwrite defined one in connection
+    """
+
+    template_fields: Sequence[str] = ('sql',)
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {
+        'sql': 'postgresql' if 'postgresql' in wwwutils.get_attr_renderer() else 'sql'
+    }
+    template_ext: Sequence[str] = ('.sql',)
+    ui_color = '#ededed'
+
+    def __init__(
+        self,
+        *,
+        sql: Union[str, List[str]],
+        postgres_conn_id: str = 'postgres_default',
+        autocommit: bool = False,
+        parameters: Optional[Union[Mapping, Iterable]] = None,
+        database: Optional[str] = None,
+        runtime_parameters: Optional[Mapping] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.sql = sql
+        self.postgres_conn_id = postgres_conn_id
+        self.autocommit = autocommit
+        self.parameters = parameters
+        self.database = database
+        self.runtime_parameters = runtime_parameters
+        self.hook: Optional[PostgresOnAzureHook] = None
+
+    def execute(self, context: 'Context'):
+        self.hook = PostgresOnAzureHook(postgres_conn_id=self.postgres_conn_id, schema=self.database)
+        if self.runtime_parameters:
+            final_sql = []
+            sql_param = {}
+            for param in self.runtime_parameters:
+                set_param_sql = f"SET {{}} TO %({param})s;"
+                dynamic_sql = SQL(set_param_sql).format(Identifier(f"{param}"))
+                final_sql.append(dynamic_sql)
+            for param, val in self.runtime_parameters.items():
+                sql_param.update({f"{param}": f"{val}"})
+            if self.parameters:
+                sql_param.update(self.parameters)
+            if isinstance(self.sql, str):
+                final_sql.append(SQL(self.sql))
+            else:
+                final_sql.extend(list(map(SQL, self.sql)))
+            self.hook.run(final_sql, self.autocommit, parameters=sql_param)
+        else:
+            self.hook.run(self.sql, self.autocommit, parameters=self.parameters)
+        for output in self.hook.conn.notices:
+            self.log.info(output)

--- a/src/plugins/postgres_update_azure_token_operator.py
+++ b/src/plugins/postgres_update_azure_token_operator.py
@@ -1,0 +1,44 @@
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, Union
+
+from postgres_on_azure_hook import PostgresOnAzureHook
+
+from airflow import settings
+from airflow.models import BaseOperator
+from airflow.models import Connection
+from airflow.utils.db import provide_session
+
+
+class PostgresUpdateAzureTokenOperator(BaseOperator):
+    """
+    Fetch an Azure AD token for the managed identity and update
+    the password field in the referenced Connection with it.
+    """
+
+    def __init__(
+        self,
+        postgres_conn_id: str = "postgres_default",
+        database: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.postgres_conn_id = postgres_conn_id
+        self.database = database
+        self.hook: Optional[PostgresOnAzureHook] = None
+
+    def execute(self, context: 'Context'):
+        self.set_password()
+
+    @provide_session
+    def set_password(self, session=None):
+        self.hook = PostgresOnAzureHook(
+            postgres_conn_id=self.postgres_conn_id, schema=self.database
+        )
+
+        # by fetching the connection, the get_iam_token method of
+        # the PostgresOnAzureHook will be called and conn will contain
+        # the updated token in the password field
+        conn = self.hook.get_conn()
+        
+        # save the connection
+        session.add(conn)
+        session.commit()

--- a/src/plugins/postgres_update_azure_token_operator.py
+++ b/src/plugins/postgres_update_azure_token_operator.py
@@ -3,8 +3,7 @@ from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, U
 from postgres_on_azure_hook import PostgresOnAzureHook
 
 from airflow.models import BaseOperator
-from airflow.utils.db import provide_session
-airflow.utils.db
+from airflow.utils.db import merge_conn
 
 class PostgresUpdateAzureTokenOperator(BaseOperator):
     """
@@ -37,8 +36,9 @@ class PostgresUpdateAzureTokenOperator(BaseOperator):
         # the updated token in the password field
         conn = self.hook.get_conn()
 
-        # generate new connection based on current connection because the new connection
-        # should not have the iam field (as that will trigger the AWS code of the vanilla postgres operator)
+        # generate new connection based on current connection because
+        # the new connection should not have the iam field
+        # (as that will trigger the AWS code of the vanilla postgres operator)
         conn_with_token = Connection(
             conn_id=self.generated_postgres_conn_id, conn_type='postgres',
             login=conn.login,

--- a/src/plugins/postgres_update_azure_token_operator.py
+++ b/src/plugins/postgres_update_azure_token_operator.py
@@ -2,9 +2,7 @@ from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, U
 
 from postgres_on_azure_hook import PostgresOnAzureHook
 
-from airflow import settings
 from airflow.models import BaseOperator
-from airflow.models import Connection
 from airflow.utils.db import provide_session
 
 

--- a/src/plugins/postgres_update_azure_token_operator.py
+++ b/src/plugins/postgres_update_azure_token_operator.py
@@ -7,8 +7,8 @@ from airflow.utils.db import merge_conn
 
 class PostgresUpdateAzureTokenOperator(BaseOperator):
     """
-    Fetch an Azure AD token for the managed identity and update
-    the password field in the referenced Connection with it.
+    Fetch an Azure AD token for the managed identity and generate a new connection
+    containing the token for the managed identity as password.
     """
 
     def __init__(


### PR DESCRIPTION
# Overzicht
Deze PR hoort bij https://dev.azure.com/CloudCompetenceCenter/Dataverwerking/_workitems/edit/50047

Omdat in PostgresOperator / PostgresHook upstream geen ondersteuning was voor Azure credentials, is die nu hier ingebouwd. Voor de lange termijn is het beter om de logica via een PR wel in de Airflow-repo te krijgen zodat we die niet meer hier hoeven beheren en zodat de DAGS ook geschreven kunnen worden op basis van standaard Airflow operators.

Deze PR voegt toe:
- PostgresOnAzureOperator
- PostgresOnAzureHook
- PostgresUpdateAzureTokenOperator

verder ter ondersteuning een aanpassing aan de testdag en een aanpassing aan de docker-compose file.

# PostgresOnAzureOperator
Dit is een kloon van de upstream [PostgresOperator](https://github.com/apache/airflow/blob/main/airflow/providers/postgres/operators/postgres.py). Subclassen heeft geen zin omdat de PostgresHook daar hard in de `execute` method staat en je geen eigen hook kunt meegeven. De PostgresOnAzureOperator gebruikt wel PostgresOnAzureHook en kan daarmee zelfstandig een token ophalen. Met deze operator kun je rechtstreeks sql-queries vanuit variables of vanuit files uitvoeren.

# PostgresOnAzureHook
Dit is een subclass van de upstream [PostgresHook](https://github.com/apache/airflow/blob/main/airflow/providers/postgres/hooks/postgres.py). Hij zorgt ervoor dat in de `get_iam_token` method een token opgehaald wordt met [`DefaultAzureCredential`](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python). `DefaultAzureCredential` zorgt ervoor dat automatisch alle soorten credentials ondersteund worden. Het zou dus ook voor lokaal testen kunnen werken want hij kan bijv. je `az login`-sessie gebruiken.

# PostgresUpdateAzureTokenOperator
Voor plekken waar een Airflow connection nodig is die niet nog een keer te token-logica gaat uitvoeren bijv. in PostgresOperator / PostgresHook (die gaat proberen een AWS-token op te halen) kun je hiermee op basis van een connection template een connection genereren met bijgewerkt token. Liever deze oplossing niet gebruiken.

# Vervolgacties
- DAGs aanpassen zodat ze gebruik maken van onze logica ipv allerlei eigen manieren (BashOperator + `psql` commando zag ik heel veel, of _get_engine in de [PostgresPermissionsOperator](https://github.com/Amsterdam/dataservices-airflow/blob/master/src/plugins/postgres_permissions_operator.py))
- Azure-logica upstreamen naar PostgresHook in Airflow 
