### PR TITLE
AB#51477 Bump flask-caching to v1.11.1

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -5,7 +5,7 @@ apache-airflow-providers-oracle==2.0.1
 apache-airflow-providers-sftp==2.4.1
 apache-airflow-providers-slack==4.2.1
 apache-airflow-providers-ssh==2.4.0
-apache-airflow[crypto,postgres,sentry,sendgrid]==2.2.4
+apache-airflow[crypto,postgres,sentry,sendgrid]==2.2.5
 authlib==1.0.1
 cattrs==1.1.2
 clevercsv==0.1.4
@@ -26,7 +26,8 @@ flake8-polyfill==1.0.2
 flake8-print==4.0.0
 flake8-rst==0.8.0
 flake8-string-format==0.3.0
-flask-appbuilder==3.4.4 # Dependencyapache-airflow[crypto,postgres,sentry,sendgrid]2.2.4 depends on flask-appbuilder==3.4.4
+flask-caching==1.11.1
+flask-appbuilder==3.4.5 # Dependencyapache-airflow[crypto,postgres,sentry,sendgrid]2.2.5 depends on flask-appbuilder==3.4.5
 flask-openid==1.3.0
 flask_bcrypt==0.7.1
 GeoAlchemy2==0.7.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,7 +15,7 @@ amsterdam-schema-tools==3.6.11
     # via -r requirements.in
 anyio==3.3.3
     # via httpcore
-apache-airflow[crypto,postgres,sendgrid,sentry]==2.2.4
+apache-airflow[crypto,postgres,sendgrid,sentry]==2.2.5
     # via
     #   -r requirements.in
     #   apache-airflow-providers-cncf-kubernetes
@@ -143,7 +143,9 @@ bcrypt==3.2.0
 blinker==1.4
     # via apache-airflow
 cachelib==0.6.0
-    # via flask-session
+    # via
+    #   flask-caching
+    #   flask-session
 cachetools==4.2.2
     # via
     #   amsterdam-schema-tools
@@ -301,7 +303,7 @@ flask==1.1.4
     #   flask-session
     #   flask-sqlalchemy
     #   flask-wtf
-flask-appbuilder==3.4.4
+flask-appbuilder==3.4.5
     # via
     #   -r requirements.in
     #   apache-airflow
@@ -309,8 +311,10 @@ flask-babel==1.0.0
     # via flask-appbuilder
 flask-bcrypt==0.7.1
     # via -r requirements.in
-flask-caching==1.10.1
-    # via apache-airflow
+flask-caching==1.11.1
+    # via
+    #   -r requirements.in
+    #   apache-airflow
 flask-jwt-extended==3.25.1
     # via flask-appbuilder
 flask-login==0.4.1
@@ -502,16 +506,16 @@ ordered-set==4.0.2
     # via deepdiff
 os-service-types==1.7.0
     # via keystoneauth1
-oslo-config==8.8.0
+oslo-config==9.0.0
     # via python-keystoneclient
 oslo-i18n==5.1.0
     # via
     #   oslo-config
     #   oslo-utils
     #   python-keystoneclient
-oslo-serialization==4.3.0
+oslo-serialization==5.0.0
     # via python-keystoneclient
-oslo-utils==4.12.2
+oslo-utils==6.0.0
     # via
     #   oslo-serialization
     #   python-keystoneclient
@@ -537,7 +541,6 @@ pbr==5.5.1
     #   os-service-types
     #   oslo-i18n
     #   oslo-serialization
-    #   oslo-utils
     #   python-keystoneclient
     #   stevedore
 pendulum==2.1.2
@@ -832,6 +835,8 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via pytest
+typing-extensions==4.3.0
+    # via apache-airflow
 unicodecsv==0.14.1
     # via apache-airflow
 urllib3==1.26.6


### PR DESCRIPTION
For critical security issue in the old version that showed up in the dependabot alerts.