### PR TITLE
sport: workarround for loopup geom based on address

### DIFF
--- a/src/plugins/typeahead_location_operator.py
+++ b/src/plugins/typeahead_location_operator.py
@@ -208,7 +208,7 @@ class TypeAHeadLocationOperator(BaseOperator):
             with pg_hook.get_cursor() as cursor:
 
                 # update record with found geometry
-                if bag_id is not None:
+                if bag_url is not None:
                     cursor.execute(
                         sql.SQL(
                             """
@@ -238,7 +238,7 @@ class TypeAHeadLocationOperator(BaseOperator):
                 # https://api.data.amsterdam.nl/atlas/typeahead/bag/?q=Gustav%20Mahlerlaan%202920
                 # TODO: Adjust the typeahead API in this repo:
                 # https://github.com/Amsterdam/bag_services/
-                if bag_id is None:
+                if bag_url is None:
                     self.log.info(
                         "Final attempt: No BAG id found for %s, \
                         attempt by query the BAG tables directly,\

--- a/src/plugins/typeahead_location_operator.py
+++ b/src/plugins/typeahead_location_operator.py
@@ -1,15 +1,17 @@
 import json
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import ParseResult, urlparse
 
 from airflow.hooks.http_hook import HttpHook
 from airflow.models.baseoperator import BaseOperator
-from postgres_on_azure_hook import PostgresOnAzureHook
+from airflow.utils.context import Context
 from airflow.utils.decorators import apply_defaults
+from postgres_on_azure_hook import PostgresOnAzureHook
 
 
 class TypeAHeadLocationOperator(BaseOperator):
-    """
+    """TypeAHeadLocationOperator.
+
     If a source doesn't contains geometry data, but does have other location data, such as
     an address then this is used to find the geometry object using the typeahead service.
 
@@ -31,7 +33,7 @@ class TypeAHeadLocationOperator(BaseOperator):
     The default name of this column is 'geometry' and can be overwritten if needed.
     """
 
-    @apply_defaults
+    @apply_defaults  # type: ignore
     def __init__(
         self,
         source_table: str,
@@ -41,18 +43,29 @@ class TypeAHeadLocationOperator(BaseOperator):
         geometry_column: str = "geometry",
         postgres_conn_id: str = "postgres_default",
         http_conn_id: str = "api_data_amsterdam_conn_id",
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         """Initialize.
 
-         args:
-            dataset_name: Name of the dataset as known in the Amsterdam schema.
-                Since the DAG name can be different from the dataset name, the latter
-                can be explicity given. Only applicable for Azure referentie db connection.
-                Defaults to None. If None, it will use the execution context to get the
-                DAG id as surrogate. Assuming that the DAG id equals the dataset name
-                as defined in Amsterdam schema.
+        Args:
+           dataset_name: Name of the dataset as known in the Amsterdam schema.
+               Since the DAG name can be different from the dataset name, the latter
+               can be explicity given. Only applicable for Azure referentie db connection.
+               Defaults to None. If None, it will use the execution context to get the
+               DAG id as surrogate. Assuming that the DAG id equals the dataset name
+               as defined in Amsterdam schema. It is used to setup the datbase user for
+               the connection to the database.
+            source_table: Name of the table to run the address to geometry lookup on.
+            source_location_column: Name of the column to run the lookup for an address to
+                geometry.
+            source_key_column: Name of the key column, used to update the correct row.
+            geometry_column: The target column to add the found geometry to.
+            postgres_conn_id: Connection name to use to setup the database connection.
+                Defaults to `postgres_default`.
+            http_conn_id: Connection name to use for the API base URL.
+                Defaults to `api_data_amsterdam_conn_id`.
+
         """
         super().__init__(*args, **kwargs)
         self.source_table = source_table
@@ -63,10 +76,11 @@ class TypeAHeadLocationOperator(BaseOperator):
         self.http_conn_id = http_conn_id
         self.dataset_name = dataset_name
 
-    def get_non_geometry_records(self, context):
-        """get location values from table (for record with no geometry)"""
-
-        pg_hook = PostgresOnAzureHook(dataset_name=self.dataset_name, context=context, postgres_conn_id=self.postgres_conn_id)
+    def get_non_geometry_records(self, context: Context) -> Any:
+        """Get location values from table (for record with no geometry)."""
+        pg_hook = PostgresOnAzureHook(
+            dataset_name=self.dataset_name, context=context, postgres_conn_id=self.postgres_conn_id
+        )
 
         with pg_hook.get_cursor() as cursor:
 
@@ -84,9 +98,14 @@ class TypeAHeadLocationOperator(BaseOperator):
 
         return rows
 
-    def prepare_typeahead_call(self, record):
-        """Prep typeahead service call for non-geometry location data"""
+    def prepare_typeahead_call(self, record: list) -> dict[str, Optional[Any]]:
+        """Prep typeahead service call for non-geometry location data.
 
+        Args:
+            record: A single row in the source table to be apply the
+                lookup from address to geometry on.
+
+        """
         # setup result list
         typeadhead_result = {}
 
@@ -103,10 +122,10 @@ class TypeAHeadLocationOperator(BaseOperator):
 
         try:
             http_data = json.loads(http_response.text)[0]["content"][0]["uri"]
-            self.log.info(f"BAG id found for {location_value}.")
+            self.log.info("BAG id found for %s", location_value)
 
         except IndexError:
-            self.log.error(f"Attempt 1: No BAG id found for {location_value}, empty result...")
+            self.log.error("Attempt 1: No BAG id found for %s, empty result...", location_value)
 
         # TODO: find better solution
         # If no match, try matching only on the first number of
@@ -118,26 +137,32 @@ class TypeAHeadLocationOperator(BaseOperator):
 
             try:
                 http_data = json.loads(http_response.text)[0]["content"][0]["uri"]
-                self.log.info(f"BAG id found for {location_value}.")
+                self.log.info("BAG id found for %s", location_value)
 
             except IndexError:
-                self.log.error(f"Attempt 2: No BAG id found for {location_value}, empty result...")
+                self.log.error(
+                    "Attempt 2: No BAG id found for %s, empty result...", location_value
+                )
 
         typeadhead_result[key_value] = http_data
 
         return typeadhead_result
 
-    def get_typeahead_result(self, http_endpoint, data_headers):
-        """Look up BAG verblijfsobject id from typeahead service for non-geometry location data"""
+    def get_typeahead_result(self, http_endpoint: str, data_headers: dict[str, str]) -> Any:
+        """Look up BAG verblijfsobject id from typeahead service for non-geometry location data.
 
+        Args:
+            http_endpoint: The endpoint of the API to use for the lookup. In this case
+                the `typeahead` API: https://api.data.amsterdam.nl/atlas/typeahead/bag/?q
+            data_headers: The API headers to add when calling it.
+        """
         http = HttpHook(method="GET", http_conn_id=self.http_conn_id)
         http_response = http.run(endpoint=http_endpoint, data=None, headers=data_headers)
 
         return http_response
 
-    def execute(self, context=None):
-        """look up the geometry where no geometry is present"""
-
+    def execute(self, context: Context) -> None:
+        """Look up the geometry based on address if no geometry is present."""
         # get location data without geometry
         rows = self.get_non_geometry_records(context=context)
 
@@ -147,47 +172,113 @@ class TypeAHeadLocationOperator(BaseOperator):
             get_typeadhead_result = self.prepare_typeahead_call(record)
             record_key = None
             bag_url = None
+            bag_id = None
+
             for key, value in get_typeadhead_result.items():
                 record_key = key
                 bag_url = value
 
-            # extract the BAG id from the url, which is the last
-            # series of numbers before the last forward-slash
-            try:
-                get_uri = urlparse(bag_url)
-                if not isinstance(get_uri, ParseResult):
-                    self.log.info(f"No BAG id found for {record}")
+                # extract the BAG id from the url, which is the last
+                # series of numbers before the last forward-slash
+                try:
+                    if bag_url:
+                        get_uri = urlparse(bag_url)
+                    if not isinstance(get_uri, ParseResult):
+                        self.log.info("No BAG id found for %s", record)
+                    else:
+                        bag_id = get_uri.path.rsplit("/")[-2]
+                        self.log.info("BAG id found for %s:%s", record_key, bag_id)
+
+                except AttributeError:
+                    self.log.error(
+                        "No BAG id found for %s %s %s, empty result...",
+                        record_key,
+                        bag_id,
+                        bag_url,
+                    )
                     continue
-                else:
-                    bag_id = get_uri.path.rsplit("/")[-2]
-                    self.log.info(f"BAG id found for {record_key}: {bag_id}")
 
-            except AttributeError:
-                self.log.error(
-                    f"No BAG id found for {record_key} {bag_id} {bag_url}, empty result..."
-                )
-                continue
-
-            pg_hook = PostgresOnAzureHook(dataset_name=self.dataset_name,context=context, postgres_conn_id=self.postgres_conn_id)
+            pg_hook = PostgresOnAzureHook(
+                dataset_name=self.dataset_name,
+                context=context,
+                postgres_conn_id=self.postgres_conn_id,
+            )
 
             with pg_hook.get_cursor() as cursor:
 
                 # update record with found geometry
-                cursor.execute(
-                    f"""
-                        WITH BAG_VBO_GEOM AS (
-                        SELECT geometrie
-                        FROM public.bag_verblijfsobjecten
-                        WHERE identificatie = %s
-                        )
-                        UPDATE {self.source_table}
-                        SET {self.geometry_column} = BAG_VBO_GEOM.geometrie
-                        FROM BAG_VBO_GEOM
-                        WHERE {self.source_key_column} = %s;
-                        COMMIT;
-                        """,
-                    (
-                        bag_id,
-                        record_key,
-                    ),
-                )
+                if bag_id is not None:
+                    cursor.execute(
+                        """
+                            WITH BAG_VBO_GEOM AS (
+                            SELECT geometrie
+                            FROM public.bag_verblijfsobjecten
+                            WHERE identificatie = %(bag_id)s
+                            )
+                            UPDATE %(source_table)s
+                            SET %(geometry_column)s = BAG_VBO_GEOM.geometrie
+                            FROM BAG_VBO_GEOM
+                            WHERE %(source_key_column)s = %(record_key)s;
+                            COMMIT;
+                            """,
+                        {
+                            "source_table": self.source_table,
+                            "geometry_column": self.geometry_column,
+                            "source_key_column": self.source_key_column,
+                            "bag_id": bag_id,
+                            "record_key": record_key,
+                        },
+                    )
+
+                # TEMPORARY: Final attempt to update the source data with geometry
+                # based on the BAG tables in the DB itself. Bypassing the
+                # use of the typahead API. Since the API cannot cope with huisnummer
+                # larger then 3 digits. See:
+                # https://api.data.amsterdam.nl/atlas/typeahead/bag/?q=Gustav%20Mahlerlaan%202920
+                # TODO: Adjust the typeahead API in this repo:
+                # https://github.com/Amsterdam/bag_services/
+                if bag_id is None:
+                    self.log.info(
+                        "Final attempt: No BAG id found for %s, \
+                        attempt by query the BAG tables directly,\
+                        bypassing the /atlas/typeahead/bag API...",
+                        record,
+                    )
+
+                    record = record[0].split(" ")
+                    index_last_value = len(record) - 1
+                    adres = " ".join(record[:index_last_value])
+                    huisnummer = "".join(record[index_last_value : index_last_value + 1])
+
+                    self.log.info("Value for `adres` to use in DB query = %s", adres)
+                    self.log.info("Value for `huisnummer` to use in DB query = %s", huisnummer)
+
+                    cursor.execute(
+                        """
+                            WITH BAG_VBO_GEOM_FULL_SEARCH AS (
+                            SELECT DISTINCT bv.geometrie
+                            FROM public.bag_verblijfsobjecten bv
+                            INNER JOIN public.bag_nummeraanduidingen_adresseert_verblijfsobject bnav
+                                ON bnav.adresseert_verblijfsobject_identificatie = bv.identificatie
+                            INNER JOIN public.bag_nummeraanduidingen bn
+                                ON bn.id = bnav.nummeraanduidingen_id
+                            INNER JOIN public.bag_openbareruimtes bo
+                                ON bo.id = bn.ligt_aan_openbareruimte_id
+                            WHERE bo.naam_nen = %(adres)s
+                            AND bn.huisnummer =  %(huisnummer)s
+                            )
+                            UPDATE %(source_table)s
+                            SET  %(geometry_column)s = BAG_VBO_GEOM_FULL_SEARCH.geometrie
+                            FROM BAG_VBO_GEOM_FULL_SEARCH
+                            WHERE  %(source_key_column)s  = %(record_key)s ;
+                            COMMIT;
+                            """,  # noqa: E501
+                        {
+                            "source_table": self.source_table,
+                            "geometry_column": self.geometry_column,
+                            "source_key_column": self.source_key_column,
+                            "adres": adres,
+                            "huisnummer": huisnummer,
+                            "record_key": record_key,
+                        },
+                    )

--- a/src/plugins/typeahead_location_operator.py
+++ b/src/plugins/typeahead_location_operator.py
@@ -258,9 +258,11 @@ class TypeAHeadLocationOperator(BaseOperator):
                             WITH BAG_VBO_GEOM_FULL_SEARCH AS (
                             SELECT DISTINCT bv.geometrie
                             FROM public.bag_verblijfsobjecten bv
-                            INNER JOIN public.bag_nummeraanduidingen_adresseert_verblijfsobject bnav
+                            INNER JOIN
+                                public.bag_nummeraanduidingen_adresseert_verblijfsobject bnav
                                 ON bnav.adresseert_verblijfsobject_identificatie = bv.identificatie
-                            INNER JOIN public.bag_nummeraanduidingen bn
+                            INNER JOIN
+                                public.bag_nummeraanduidingen bn
                                 ON bn.id = bnav.nummeraanduidingen_id
                             INNER JOIN public.bag_openbareruimtes bo
                                 ON bo.id = bn.ligt_aan_openbareruimte_id
@@ -272,7 +274,7 @@ class TypeAHeadLocationOperator(BaseOperator):
                             FROM BAG_VBO_GEOM_FULL_SEARCH
                             WHERE  %(source_key_column)s  = %(record_key)s ;
                             COMMIT;
-                            """,  # noqa: E501
+                            """,
                         {
                             "source_table": self.source_table,
                             "geometry_column": self.geometry_column,


### PR DESCRIPTION
The typeahead API is having some issue with house number > 3. For now a temporary workarround is added to the typeaheadoperator to deal with this situation and being able to lookup the geometry for an address with house number greater then 3 digits.