### PR TITLE
bump postgres provider and fix dns cursor error gob

### DIFF
--- a/src/config/airflow.cfg
+++ b/src/config/airflow.cfg
@@ -333,7 +333,7 @@ statsd_prefix = airflow
 
 [api]
 # How to authenticate users of the API
-auth_backends = airflow.api.auth.backend.default
+auth_backends = airflow.api.auth.backend.basic_auth
 
 [lineage]
 # what lineage backend to use

--- a/src/plugins/http_gob_operator.py
+++ b/src/plugins/http_gob_operator.py
@@ -178,7 +178,6 @@ class HttpGobOperator(BaseOperator):
             dataset = dataset_schema_from_url(
                 dataset_info.schema_url, dataset_info.dataset_id, prefetch_related=True
             )
-            # importer = NDJSONImporter(dataset, pg_hook.get_sqlalchemy_engine(), logger=self.log)
             importer = NDJSONImporter(
                 dataset,
                 pg_hook.get_sqlalchemy_engine(split_dictcursor=True),

--- a/src/plugins/http_gob_operator.py
+++ b/src/plugins/http_gob_operator.py
@@ -178,7 +178,12 @@ class HttpGobOperator(BaseOperator):
             dataset = dataset_schema_from_url(
                 dataset_info.schema_url, dataset_info.dataset_id, prefetch_related=True
             )
-            importer = NDJSONImporter(dataset, pg_hook.get_sqlalchemy_engine(), logger=self.log)
+            # importer = NDJSONImporter(dataset, pg_hook.get_sqlalchemy_engine(), logger=self.log)
+            importer = NDJSONImporter(
+                dataset,
+                pg_hook.get_sqlalchemy_engine(split_dictcursor=True),
+                logger=self.log
+                )
 
             importer.generate_db_objects(
                 table_id=dataset_info.table_id,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -37,7 +37,7 @@ apache-airflow-providers-microsoft-azure==3.2.0
     # via -r requirements.in
 apache-airflow-providers-oracle==2.0.1
     # via -r requirements.in
-apache-airflow-providers-postgres==2.4.0
+apache-airflow-providers-postgres==5.2.1
     # via apache-airflow
 apache-airflow-providers-sendgrid==2.0.1
     # via apache-airflow


### PR DESCRIPTION
- bumping postgres provider to 5.2.1 so the postgres hook will rename any postgres protocol name to postgresql
- removing the URL param cursor from connection string GOB dags since it causes error after upgrade SQLalchemy.