### PR TITLE
Airflow bump to 2.4.1

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -5,7 +5,8 @@ apache-airflow-providers-oracle==2.0.1
 apache-airflow-providers-sftp==2.4.1
 apache-airflow-providers-slack==4.2.1
 apache-airflow-providers-ssh==2.4.0
-apache-airflow[crypto,postgres,sentry,sendgrid]==2.3.4 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.3.4/constraints-3.7.txt"
+apache-airflow[crypto,postgres,sentry,sendgrid]==2.4.1 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.4.1/constraints-3.9.txt"
+attrs==22.1.0
 authlib==1.0.1
 clevercsv==0.1.4
 cryptography==3.4.8
@@ -16,12 +17,12 @@ dsnparse==0.1.15
 environs==9.3.3
 flake8==3.9.2
 flake8-bandit==2.1.2
-flake8-bugbear==21.3.2
+flake8-bugbear==22.9.23
 flake8-builtins==1.5.3
 flake8-colors==0.1.9
 flake8-comprehensions==3.4.0
 flake8-docstrings==1.6.0
-flake8-implicit-str-concat==0.2.0
+flake8-implicit-str-concat==0.3.0
 flake8-polyfill==1.0.2
 flake8-print==4.0.0
 flake8-rst==0.8.0
@@ -51,7 +52,7 @@ pytest-env==0.6.2
 pytest-helpers-namespace==2021.04.29
 pytest-mock==3.6.1
 pytest-postgresql==4.0.0
-pytest==6.2.5
+pytest==7.1.3
 python-json-logger==2.0.2
 python-keystoneclient==4.0.0
 python-string-utils==1.0.0
@@ -64,3 +65,4 @@ sqlalchemy==1.4.27
 validator-collection==1.4.1
 xlrd==1.2.0
 yamlip==0.0.2
+zeep==4.1.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,7 +15,7 @@ amsterdam-schema-tools==4.2.2
     # via -r requirements.in
 anyio==3.6.1
     # via httpcore
-apache-airflow[crypto,postgres,sendgrid,sentry]==2.3.4
+apache-airflow[crypto,postgres,sendgrid,sentry]==2.4.1
     # via
     #   -r requirements.in
     #   apache-airflow-providers-cncf-kubernetes
@@ -30,6 +30,7 @@ apache-airflow-providers-cncf-kubernetes==4.3.0
     # via -r requirements.in
 apache-airflow-providers-common-sql==1.2.0
     # via
+    #   apache-airflow
     #   apache-airflow-providers-postgres
     #   apache-airflow-providers-sqlite
 apache-airflow-providers-ftp==3.1.0
@@ -64,14 +65,17 @@ arrow==1.2.3
     # via isoduration
 attrdict==2.0.1
     # via yamlip
-attrs==20.3.0
+attrs==22.1.0
     # via
+    #   -r requirements.in
+    #   apache-airflow
     #   cattrs
     #   flake8-bugbear
     #   flake8-implicit-str-concat
     #   jsonschema
     #   pg-grant
     #   pytest
+    #   zeep
 authlib==1.0.1
     # via -r requirements.in
 azure-batch==12.0.0
@@ -149,6 +153,8 @@ bcrypt==4.0.1
     #   paramiko
 blinker==1.5
     # via apache-airflow
+cached-property==1.5.2
+    # via zeep
 cachelib==0.9.0
     # via
     #   flask-caching
@@ -194,6 +200,8 @@ colorlog==4.8.0
     # via apache-airflow
 commonmark==0.9.1
     # via rich
+configupdater==3.1.1
+    # via apache-airflow
 connexion[flask,swagger-ui]==2.14.1
     # via apache-airflow
 cron-descriptor==1.2.31
@@ -274,7 +282,7 @@ flake8==3.9.2
     #   flake8-string-format
 flake8-bandit==2.1.2
     # via -r requirements.in
-flake8-bugbear==21.3.2
+flake8-bugbear==22.9.23
     # via -r requirements.in
 flake8-builtins==1.5.3
     # via -r requirements.in
@@ -284,7 +292,7 @@ flake8-comprehensions==3.4.0
     # via -r requirements.in
 flake8-docstrings==1.6.0
     # via -r requirements.in
-flake8-implicit-str-concat==0.2.0
+flake8-implicit-str-concat==0.3.0
     # via -r requirements.in
 flake8-polyfill==1.0.2
     # via
@@ -388,7 +396,9 @@ iso8601==1.1.0
     #   keystoneauth1
     #   oslo-utils
 isodate==0.6.1
-    # via msrest
+    # via
+    #   msrest
+    #   zeep
 isoduration==20.11.0
     # via jsonschema
 itsdangerous==2.1.2
@@ -440,6 +450,8 @@ lockfile==0.12.2
     # via
     #   apache-airflow
     #   python-daemon
+lxml==4.9.1
+    # via zeep
 mako==1.2.2
     # via
     #   -r requirements.in
@@ -580,6 +592,8 @@ pendulum==2.1.2
     #   apache-airflow
 pg-grant==0.3.2
     # via amsterdam-schema-tools
+platformdirs==2.5.2
+    # via zeep
 pluggy==1.0.0
     # via
     #   apache-airflow
@@ -654,7 +668,7 @@ pysftp==0.2.9
     #   apache-airflow-providers-ssh
 pyshp==2.1.0
     # via -r requirements.in
-pytest==6.2.5
+pytest==7.1.3
     # via
     #   -r requirements.in
     #   pytest-env
@@ -719,6 +733,7 @@ pytz==2022.4
     #   oslo-serialization
     #   oslo-utils
     #   pandas
+    #   zeep
 pytzdata==2020.1
     # via pendulum
 pyyaml==6.0
@@ -752,14 +767,20 @@ requests==2.28.1
     #   oslo-config
     #   python-keystoneclient
     #   python-swiftclient
+    #   requests-file
     #   requests-oauthlib
     #   requests-toolbelt
+    #   zeep
+requests-file==1.5.1
+    # via zeep
 requests-oauthlib==1.3.1
     # via
     #   kubernetes
     #   msrest
 requests-toolbelt==0.10.0
-    # via apache-airflow-providers-http
+    # via
+    #   apache-airflow-providers-http
+    #   zeep
 rfc3339-validator==0.1.4
     # via jsonschema
 rfc3986[idna2008]==1.5.0
@@ -810,6 +831,7 @@ six==1.16.0
     #   python-dateutil
     #   python-keystoneclient
     #   python-swiftclient
+    #   requests-file
     #   rfc3339-validator
     #   singledispatch
     #   wirerope
@@ -870,7 +892,7 @@ termcolor==2.0.1
     # via apache-airflow
 text-unidecode==1.3
     # via python-slugify
-toml==0.10.2
+tomli==2.0.1
     # via pytest
 typing-extensions==4.4.0
     # via
@@ -915,6 +937,8 @@ wtforms==2.3.3
 xlrd==1.2.0
     # via -r requirements.in
 yamlip==0.0.2
+    # via -r requirements.in
+zeep==4.1.0
     # via -r requirements.in
 zipp==3.9.0
     # via importlib-metadata


### PR DESCRIPTION
Raising Airflow version to 2.4.1.

Libraries adjusted:
- apache-airflow to 2.4.1
- attrs to 22.1.0
- pytest to 7.1.3
- zeep to 4.1.0