### PR TITLE
Fix retrieve source field cursor in http_gob_operatator

### DIFF
--- a/src/plugins/http_gob_operator.py
+++ b/src/plugins/http_gob_operator.py
@@ -283,7 +283,7 @@ class HttpGobOperator(BaseOperator):
                     "The last-record contains now: %s",
                     last_record,
                 )
-                cursor_pos = last_record["cursor"]
+                cursor_pos = last_record.source["cursor"]
 
         # On successfull completion, remove cursor_pos variable
         Variable.delete(f"{dataset_table_id}.cursor_pos")


### PR DESCRIPTION
In version schema-tools 5.0.0 the source data is located in an instance attribute called source. The HTTP GOB OPERATOR needs to look this attribute when looking for field `cursor`.