### PR TITLE
schema-from-url-fix

### DIFF
--- a/src/dags/gob.py
+++ b/src/dags/gob.py
@@ -161,7 +161,7 @@ def create_gob_dag(
         )
 
         def _create_dataset_info(dataset_id: str, table_id: str, sub_table_id: str) -> DatasetInfo:
-            dataset = dataset_schema_from_url(SCHEMA_URL, dataset_id, prefetch_related=True)
+            dataset = dataset_schema_from_url(SCHEMA_URL).get_dataset(dataset_id, prefetch_related=True)
 
             # Fetch the db_name for this dataset and table
             if sub_table_id is not None:

--- a/src/plugins/http_gob_operator.py
+++ b/src/plugins/http_gob_operator.py
@@ -175,9 +175,8 @@ class HttpGobOperator(BaseOperator):
             # we know the schema, can be an input param (dataset_schema_from_url function)
             # We use the ndjson importer from schematools, give it a tmp tablename
             pg_hook = PostgresOnAzureHook(dataset_name=dataset_info.dataset_id, context=context)
-            dataset = dataset_schema_from_url(
-                dataset_info.schema_url, dataset_info.dataset_id, prefetch_related=True
-            )
+            dataset = dataset_schema_from_url(dataset_info.schema_url).get_dataset(dataset_info.dataset_id, prefetch_related=True)
+
             importer = NDJSONImporter(
                 dataset,
                 pg_hook.get_sqlalchemy_engine(split_dictcursor=True),

--- a/src/plugins/postgres_permissions_operator.py
+++ b/src/plugins/postgres_permissions_operator.py
@@ -175,11 +175,8 @@ class PostgresPermissionsOperator(BaseOperator):
                             logger.info("set grants for %s", dataset)
 
                             try:
-                                ams_schema = dataset_schema_from_url(
-                                    schemas_url=self.schema_url,
-                                    dataset_name=dataset,
-                                    prefetch_related=True,
-                                )
+                                ams_schema = dataset_schema_from_url(self.schema_url).get_dataset(
+                                    dataset, prefetch_related=True)
 
                                 apply_schema_and_profile_permissions(
                                     engine=engine,

--- a/src/plugins/postgres_table_copy_operator.py
+++ b/src/plugins/postgres_table_copy_operator.py
@@ -298,9 +298,8 @@ class PostgresTableCopyOperator(BaseOperator, XComAttrAssignerMixin):
                         in Amsterdam schema definition."""
                 )
 
-                dataset: DatasetSchema = dataset_schema_from_url(
-                    SCHEMA_URL, self.dataset_name_lookup
-                )
+                dataset: DatasetSchema = dataset_schema_from_url(SCHEMA_URL).get_dataset(
+                                    self.dataset_name_lookup)
 
                 # Get the table_id from the full sql table name.
                 # Because dataset names can hold letters followed by numbers

--- a/src/plugins/provenance_drop_from_schema_operator.py
+++ b/src/plugins/provenance_drop_from_schema_operator.py
@@ -44,7 +44,9 @@ class ProvenanceDropFromSchemaOperator(BaseOperator):
 
     def execute(self, context: Optional[Context] = None) -> None:
         """Main execution logic."""
-        dataset = dataset_schema_from_url(SCHEMA_URL, self.dataset_name)
+        dataset = dataset_schema_from_url(SCHEMA_URL).get_dataset(
+                                    self.dataset_name)
+
         pg_hook = PostgresOnAzureHook(
             dataset_name=self.dataset_name, context=context, postgres_conn_id=self.postgres_conn_id
         )

--- a/src/plugins/provenance_rename_operator.py
+++ b/src/plugins/provenance_rename_operator.py
@@ -166,7 +166,8 @@ class ProvenanceRenameOperator(BaseOperator):
             SQL alter statements to change database table names, columns and or indexes
 
         """
-        dataset = dataset_schema_from_url(SCHEMA_URL, self.dataset_name)
+        dataset = dataset_schema_from_url(SCHEMA_URL).get_dataset(
+                                    self.dataset_name)
         pg_hook = PostgresOnAzureHook(
             dataset_name=self.dataset_name, context=context, postgres_conn_id=self.postgres_conn_id
         )

--- a/src/plugins/sqlalchemy_create_object_operator.py
+++ b/src/plugins/sqlalchemy_create_object_operator.py
@@ -130,9 +130,8 @@ class SqlAlchemyCreateObjectOperator(BaseOperator, XComAttrAssignerMixin):
         kwargs = {"pg_schemas": [self.pg_schema]} if self.pg_schema is not None else {}
         engine = _get_engine(default_db_conn, **kwargs)
 
-        dataset_schema = dataset_schema_from_url(
-            SCHEMA_URL, self.data_schema_name, prefetch_related=True
-        )
+        dataset_schema = dataset_schema_from_url(SCHEMA_URL).get_dataset(
+                                    self.data_schema_name, prefetch_related=True)
 
         importer = BaseImporter(dataset_schema, engine, logger=self.log)
         self.log.info(

--- a/src/plugins/swap_schema_operator.py
+++ b/src/plugins/swap_schema_operator.py
@@ -53,7 +53,9 @@ class SwapSchemaOperator(BaseOperator):
             table is moved to the defined schema (a.k.a. schema swapping)
 
         """
-        dataset = dataset_schema_from_url(SCHEMA_URL, self.dataset_name)
+        dataset = dataset_schema_from_url(SCHEMA_URL).get_dataset(
+                                    self.dataset_name)
+
         pg_hook = PostgresOnAzureHook(
             dataset_name=self.dataset_name, context=context, postgres_conn_id=self.postgres_conn_id
         )


### PR DESCRIPTION
Due to the new schema-tool version (starting from 5.0.1) the import of the package that holds the `dataset_schema_from_url` has been changed. Also the method accepts slightly changed parameters.