### PR TITLE
Stroomstoring: fix regarding to schema-tools 5.0.

### DIFF
--- a/src/plugins/sqlalchemy_create_object_operator.py
+++ b/src/plugins/sqlalchemy_create_object_operator.py
@@ -148,7 +148,7 @@ class SqlAlchemyCreateObjectOperator(BaseOperator, XComAttrAssignerMixin):
 
         for table in dataset_schema.tables:
             self.log.info("Considering table '%s'.", table.db_name)
-            cur_table = f"{self.data_schema_name}_{table.db_name}"
+            cur_table = table.db_name
 
             if re.fullmatch(self.data_table_name, to_snake_case(cur_table)):
                 self.log.info(


### PR DESCRIPTION
The 'tables' instance property for as a result of schematools.loaders.get_schema_loader includes now the dataset as part of the table name. Therefore adding the dataset name explicitly to the table name is not needed any more.