### PR TITLE
Ondergrond: Account for multi geometry types within one table.

### DIFF
--- a/src/dags/sql/ondergrond.py
+++ b/src/dags/sql/ondergrond.py
@@ -1,0 +1,10 @@
+from typing import Final
+
+# convert geometry datatype to geometry (generic) so
+# it can process multi geometry types; like multipolygon and
+# collections in the same table.
+SET_DATATYPE_GEOM_TO_GEOM: Final = """
+ALTER TABLE {{ params.tablename }} ALTER COLUMN {{ params.geo_column }}
+TYPE GEOMETRY(GEOMETRY, {{ params.srid }}) USING ST_Multi({{ params.geo_column }});
+COMMIT;
+"""


### PR DESCRIPTION
Data holds multipolygon and geometry collections. The steps to ingest and to validate the source data must take this duality into account. Currently by using the ingest with ogr2ogr the datatype of the geometry column will be set to multipolygon instead of geometry (generic).