### PR TITLE
Update schema-tools to v5.8.2

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-amsterdam-schema-tools==5.8.1
+amsterdam-schema-tools==5.8.2
 apache-airflow-providers-cncf-kubernetes==4.3.0
 apache-airflow-providers-microsoft-azure==3.2.0
 apache-airflow-providers-oracle==2.0.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,7 +11,7 @@ adal==1.2.7
     #   msrestazure
 alembic==1.8.1
     # via apache-airflow
-amsterdam-schema-tools==5.8.1
+amsterdam-schema-tools==5.8.2
     # via -r requirements.in
 anyio==3.6.1
     # via httpcore


### PR DESCRIPTION
bevat bugfix voor eerdere update naar 5.8.1